### PR TITLE
feat: セッションタイムアウト時にログイン画面へ自動リダイレクト

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,105 @@
+/**
+ * APIクライアント - セッションタイムアウト時の自動リダイレクト対応
+ */
+
+/**
+ * 共通のfetchラッパー関数
+ * 401エラー（セッションタイムアウト）時にログイン画面へリダイレクト
+ */
+export async function apiFetch<T = unknown>(
+  url: string,
+  options?: RequestInit
+): Promise<T> {
+  try {
+    const response = await fetch(url, {
+      ...options,
+      headers: {
+        'Content-Type': 'application/json',
+        ...options?.headers,
+      },
+    });
+
+    if (!response.ok) {
+      // 401エラー（認証エラー）の場合はログイン画面へリダイレクト
+      if (response.status === 401) {
+        console.warn('🔒 Session timeout: Redirecting to login page');
+        // ローカルストレージをクリア
+        if (typeof window !== 'undefined') {
+          localStorage.removeItem('accessToken');
+          localStorage.removeItem('refreshToken');
+          localStorage.removeItem('userData');
+          // ログイン画面へリダイレクト
+          window.location.href = '/';
+        }
+      }
+
+      const errorData = await response.json().catch(() => ({
+        message: 'Unknown error',
+      }));
+
+      throw new Error(errorData.error || errorData.message || `HTTP error! status: ${response.status}`);
+    }
+
+    return response.json();
+  } catch (error) {
+    console.error('❌ API Request failed:', error);
+    throw error;
+  }
+}
+
+/**
+ * GETリクエスト用のヘルパー関数
+ */
+export async function apiGet<T = unknown>(
+  url: string,
+  options?: RequestInit
+): Promise<T> {
+  return apiFetch<T>(url, {
+    ...options,
+    method: 'GET',
+  });
+}
+
+/**
+ * POSTリクエスト用のヘルパー関数
+ */
+export async function apiPost<T = unknown>(
+  url: string,
+  data?: unknown,
+  options?: RequestInit
+): Promise<T> {
+  return apiFetch<T>(url, {
+    ...options,
+    method: 'POST',
+    body: data ? JSON.stringify(data) : undefined,
+  });
+}
+
+/**
+ * PATCHリクエスト用のヘルパー関数
+ */
+export async function apiPatch<T = unknown>(
+  url: string,
+  data?: unknown,
+  options?: RequestInit
+): Promise<T> {
+  return apiFetch<T>(url, {
+    ...options,
+    method: 'PATCH',
+    body: data ? JSON.stringify(data) : undefined,
+  });
+}
+
+/**
+ * DELETEリクエスト用のヘルパー関数
+ */
+export async function apiDelete<T = unknown>(
+  url: string,
+  options?: RequestInit
+): Promise<T> {
+  return apiFetch<T>(url, {
+    ...options,
+    method: 'DELETE',
+  });
+}
+

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -2,6 +2,8 @@
  * 認証関連のAPIクライアント
  */
 
+import { apiPost } from '@/lib/api'
+
 export interface PreRegisterRequest {
   email: string
   campaignCode?: string
@@ -21,32 +23,11 @@ export async function preRegister(
   campaignCode?: string
 ): Promise<PreRegisterResponse> {
   try {
-    const response = await fetch('/api/auth/pre-register', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        email,
-        campaignCode,
-      }),
+    const data = await apiPost<PreRegisterResponse>('/api/auth/pre-register', {
+      email,
+      campaignCode,
     })
 
-    // デバッグログ
-    console.log('preRegister response:', {
-      status: response.status,
-      ok: response.ok,
-      statusText: response.statusText
-    })
-
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}))
-      // エラーメッセージの正規化
-      const message = errorData.message || '認証メールの送信に失敗しました'
-      throw new Error(message)
-    }
-
-    const data = await response.json()
     console.log('preRegister success data:', data)
     return data
   } catch (error) {


### PR DESCRIPTION
## 概要
セッションタイムアウト（401エラー）が発生した際に、自動的にログイン画面へリダイレクトする機能を追加しました。

## 変更内容
### 新規作成
- `frontend/src/lib/api.ts`: 共通APIクライアントを作成
  - 401エラー発生時にローカルストレージのトークン情報をクリア
  - ログイン画面（/）へ自動リダイレクト
  - ヘルパー関数を提供: `apiGet`, `apiPost`, `apiPatch`, `apiDelete`

### 更新
- `frontend/src/app/page.tsx`: 新しいAPIクライアント（`apiPost`）を使用
  - パスワード認証、OTP認証、OTP再送信の処理を更新
- `frontend/src/services/auth.ts`: `preRegister`関数を新しいAPIクライアントを使用するように更新

## 動作
- API呼び出し時に401エラーが返された場合、ユーザーは自動的にログイン画面（/）に遷移します
- 認証情報は自動的にクリアされるため、再ログインが必要です

## 関連PR
- tamanomi-admin: https://github.com/HV-development/tamanomi-admin/pull/7