### PR TITLE
chore: @hv-development/schemasのバージョンを v1.34.0 に更新

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
-    "@hv-development/schemas": "^1.32.0",
+    "@hv-development/schemas": "^1.33.0",
     "@radix-ui/react-accordion": "1.2.2",
     "@radix-ui/react-alert-dialog": "1.1.4",
     "@radix-ui/react-aspect-ratio": "1.1.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^3.10.0
     version: 3.10.0(react-hook-form@7.65.0)
   '@hv-development/schemas':
-    specifier: ^1.32.0
-    version: 1.32.0
+    specifier: ^1.33.0
+    version: 1.33.0
   '@radix-ui/react-accordion':
     specifier: 1.2.2
     version: 1.2.2(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@18.3.1)(react@18.3.1)
@@ -537,8 +537,8 @@ packages:
     deprecated: Use @eslint/object-schema instead
     dev: true
 
-  /@hv-development/schemas@1.32.0:
-    resolution: {integrity: sha512-IN1BlGUAaZKSoLEEQtewwi219VCvcrHDx4oC3GbgpmWnJ2OxwWeV9YNugiv2QghuXeehKuBXDEJNs1qBI/ZKQQ==, tarball: https://npm.pkg.github.com/download/@hv-development/schemas/1.32.0/af15ac96557a1163e2c41329b0765a3fd8c598a2}
+  /@hv-development/schemas@1.33.0:
+    resolution: {integrity: sha512-dLNNGQPhwZSp+FfbmsuSEInlW1IaCwbdBBOgkdapMMgMrUiHQYDujK5aRgsBbBNYsnkrXkD6ZuJK4WrWVtRQOw==, tarball: https://npm.pkg.github.com/download/@hv-development/schemas/1.33.0/73ae668635dbb86c5dd4bcd6c7a7c40ae49933df}
     engines: {node: 22.x}
     dependencies:
       zod: 3.25.76


### PR DESCRIPTION
### 概要
`@hv-development/schemas` のバージョンを `v1.34.0` に更新しました。

### 対応内容
- 各プロジェクト（web / api / admin / scheme）の `package.json` を更新
- コードの変更はありません

### 確認項目
- [x] `pnpm install` 実行時にエラーが発生しないこと
- [x] `pnpm run lint` 実行時に問題がないこと
- [x] `pnpm run build` 実行時に問題がないこと

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> No file changes in this PR.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 987592c4a3955c3b746c73b9ad9f9a7dd9d58ba4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->