### PR TITLE
feat: 友達紹介機能の実装とリンター修正

### DIFF
--- a/frontend/src/app/api/auth/pre-register/route.ts
+++ b/frontend/src/app/api/auth/pre-register/route.ts
@@ -21,18 +21,44 @@ export async function POST(request: NextRequest) {
 
     const fullUrl = buildApiUrl('/pre-register');
     
-    console.log('🔍 [pre-register] Request:', { url: fullUrl, email: body.email, campaignCode: body.campaignCode });
+    console.log('🔍 [pre-register] Request:', { 
+      url: fullUrl, 
+      email: body.email, 
+      campaignCode: body.campaignCode,
+      referrerUserId: body.referrerUserId,
+      hasReferrerUserId: !!body.referrerUserId,
+      referrerUserIdType: typeof body.referrerUserId,
+      referrerUserIdLength: body.referrerUserId?.length,
+      allBodyKeys: Object.keys(body),
+    });
 
     try {
+      const requestBody: any = {
+        email: body.email,
+        campaignCode: body.campaignCode,
+      };
+      
+      // 紹介者IDがある場合は追加
+      if (body.referrerUserId && body.referrerUserId.trim() !== '') {
+        requestBody.referrerUserId = body.referrerUserId.trim();
+        console.log('🔍 [pre-register] Added referrerUserId to requestBody:', requestBody.referrerUserId);
+      } else {
+        console.log('🔍 [pre-register] No referrerUserId in body, skipping');
+      }
+      
+      console.log('🔍 [pre-register] Final requestBody:', {
+        email: requestBody.email,
+        campaignCode: requestBody.campaignCode,
+        hasReferrerUserId: 'referrerUserId' in requestBody,
+        referrerUserId: requestBody.referrerUserId,
+      });
+
       const response = await fetch(fullUrl, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({
-          email: body.email,
-          campaignCode: body.campaignCode,
-        }),
+        body: JSON.stringify(requestBody),
         signal: controller.signal,
       });
 

--- a/frontend/src/app/api/auth/register/route.ts
+++ b/frontend/src/app/api/auth/register/route.ts
@@ -15,10 +15,13 @@ export async function POST(request: NextRequest) {
       saitamaAppIdType: typeof body.saitamaAppId,
       saitamaAppIdLength: body.saitamaAppId?.length,
       saitamaAppIdValue: `"${body.saitamaAppId}"`,
+      referrerUserId: body.referrerUserId,
+      referrerUserIdType: typeof body.referrerUserId,
+      referrerUserIdLength: body.referrerUserId?.length,
     })
 
     // バックエンドが期待するデータ構造に変換
-    // 空文字列のsaitamaAppIdは除外
+    // 空文字列のsaitamaAppIdとreferrerUserIdは除外
     const validatedData = {
       email: body.email,
       password: body.password,
@@ -30,6 +33,7 @@ export async function POST(request: NextRequest) {
       gender: body.gender,
       phone: body.phone,
       ...(body.saitamaAppId && body.saitamaAppId.trim() !== '' ? { saitamaAppId: body.saitamaAppId.trim() } : {}),
+      ...(body.referrerUserId && body.referrerUserId.trim() !== '' ? { referrerUserId: body.referrerUserId.trim() } : {}),
       token: body.token
     };
 
@@ -38,6 +42,8 @@ export async function POST(request: NextRequest) {
       nickname: validatedData.nickname,
       hasSaitamaAppId: 'saitamaAppId' in validatedData,
       saitamaAppId: 'saitamaAppId' in validatedData ? validatedData.saitamaAppId : undefined,
+      hasReferrerUserId: 'referrerUserId' in validatedData,
+      referrerUserId: 'referrerUserId' in validatedData ? validatedData.referrerUserId : undefined,
     })
 
     // タイムアウト設定付きのfetch

--- a/frontend/src/app/api/auth/register/verify/[token]/route.ts
+++ b/frontend/src/app/api/auth/register/verify/[token]/route.ts
@@ -2,10 +2,10 @@ import { NextRequest, NextResponse } from 'next/server'
 
 export async function GET(
     request: NextRequest,
-    { params }: { params: { token: string } }
+    { params }: { params: Promise<{ token: string }> }
 ) {
     try {
-        const { token } = params
+        const { token } = await params
 
         if (!token) {
             return NextResponse.redirect(new URL('/email-registration?error=invalid_token', request.url))
@@ -30,6 +30,12 @@ export async function GET(
             const registerUrl = new URL('/register', request.url)
             registerUrl.searchParams.set('email', tokenData.email)
             registerUrl.searchParams.set('token', token)
+            
+            // URLパラメータから紹介者IDを取得して含める
+            const ref = request.nextUrl.searchParams.get('ref')
+            if (ref) {
+              registerUrl.searchParams.set('ref', ref)
+            }
 
             return NextResponse.redirect(registerUrl)
         } catch {

--- a/frontend/src/app/api/favorites/[shopId]/route.ts
+++ b/frontend/src/app/api/favorites/[shopId]/route.ts
@@ -7,11 +7,11 @@ export const dynamic = 'force-dynamic'
 // お気に入り登録/削除（トグル）
 export async function POST(
   request: NextRequest,
-  { params }: { params: { shopId: string } }
+  { params }: { params: Promise<{ shopId: string }> }
 ) {
   try {
     const authHeader = getAuthHeader(request)
-    const { shopId } = params
+    const { shopId } = await params
     
     if (!authHeader) {
       console.log('❌ [favorites] No authorization header')
@@ -79,11 +79,11 @@ export async function POST(
 // お気に入り削除
 export async function DELETE(
   request: NextRequest,
-  { params }: { params: { shopId: string } }
+  { params }: { params: Promise<{ shopId: string }> }
 ) {
   try {
     const authHeader = getAuthHeader(request)
-    const { shopId } = params
+    const { shopId } = await params
     
     if (!authHeader) {
       console.log('❌ [favorites] No authorization header')

--- a/frontend/src/app/api/payment/session/[customer_id]/route.ts
+++ b/frontend/src/app/api/payment/session/[customer_id]/route.ts
@@ -6,10 +6,10 @@ export const dynamic = 'force-dynamic'
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { customer_id: string } }
+  { params }: { params: Promise<{ customer_id: string }> }
 ) {
   try {
-    const customerId = params.customer_id
+    const { customer_id: customerId } = await params
     
     // API_BASE_URLから末尾の/api/v1を削除（重複を防ぐ）
     const fullUrl = buildApiUrl(`/payment/session/${customerId}`)

--- a/frontend/src/app/api/shops/route.ts
+++ b/frontend/src/app/api/shops/route.ts
@@ -53,22 +53,41 @@ export async function GET(request: NextRequest) {
 
     console.log('[api/shops] backend status:', response.status)
 
-    const data = await response.json().catch(() => ({}))
+    let data: any = {}
+    try {
+      const contentType = response.headers.get('content-type')
+      if (contentType && contentType.includes('application/json')) {
+        data = await response.json()
+      } else {
+        const text = await response.text()
+        console.error('[api/shops] backend returned non-JSON response:', text.substring(0, 200))
+        data = { message: text.substring(0, 200) }
+      }
+    } catch (parseError) {
+      console.error('[api/shops] failed to parse response:', parseError)
+      data = { message: 'レスポンスの解析に失敗しました' }
+    }
+
     if (process.env.NODE_ENV !== 'production') {
       console.log('[api/shops] backend payload sample:', {
-        shopsCount: Array.isArray((data as any)?.shops) ? (data as any).shops.length : 'n/a',
-        pagination: (data as any)?.pagination || null,
+        shopsCount: Array.isArray(data?.shops) ? data.shops.length : 'n/a',
+        pagination: data?.pagination || null,
+        hasError: !!data?.error,
       })
     }
 
     if (!response.ok) {
       // 500系は文言を統一
       if (response.status >= 500) {
+        console.error('[api/shops] backend 5xx error:', {
+          status: response.status,
+          data,
+        })
         return NextResponse.json(
           {
             error: {
               code: 'INTERNAL_SERVER_ERROR',
-              message: '店舗情報の取得に失敗しました。時間を置いて再度お試しください。',
+              message: data?.error?.message || data?.message || '店舗情報の取得に失敗しました。時間を置いて再度お試しください。',
             },
           },
           { status: 500 }
@@ -76,11 +95,15 @@ export async function GET(request: NextRequest) {
       }
 
       // 4xx などはバックエンドのエラーをそのまま返す
+      console.error('[api/shops] backend 4xx error:', {
+        status: response.status,
+        data,
+      })
       return NextResponse.json(
         {
           error: data?.error || {
             code: 'API_ERROR',
-            message: data?.message || '店舗情報の取得に失敗しました',
+            message: data?.message || data?.error?.message || '店舗情報の取得に失敗しました',
           },
         },
         { status: response.status }

--- a/frontend/src/app/email-registration/page.tsx
+++ b/frontend/src/app/email-registration/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Suspense } from 'react'
+import { Suspense, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { EmailRegistrationContainer } from '@/components/organisms/EmailRegistrationContainer'
 import { useEmailRegistration } from '@/hooks/useEmailRegistration'
@@ -16,6 +16,31 @@ function EmailRegistrationContent() {
     handleEmailSubmit,
     handleResend,
   } = useEmailRegistration()
+
+  // URLパラメータから紹介者IDを取得してセッションストレージに保存
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const urlParams = new URLSearchParams(window.location.search)
+      const ref = urlParams.get('ref')
+      console.log('🔍 [email-registration] URL params:', {
+        search: window.location.search,
+        ref,
+        allParams: Object.fromEntries(urlParams.entries()),
+      })
+      if (ref) {
+        sessionStorage.setItem('referrerUserId', ref)
+        console.log('🔍 [email-registration] referrerUserId saved to sessionStorage:', ref)
+        // 保存後に確認
+        const saved = sessionStorage.getItem('referrerUserId')
+        console.log('🔍 [email-registration] Verified saved referrerUserId:', saved)
+      } else {
+        console.log('🔍 [email-registration] No ref parameter found in URL')
+        // 既存の値を確認
+        const existing = sessionStorage.getItem('referrerUserId')
+        console.log('🔍 [email-registration] Existing referrerUserId in sessionStorage:', existing)
+      }
+    }
+  }, [])
 
   const handleBack = () => router.push('/')
   const handleLogoClick = () => router.push('/')

--- a/frontend/src/app/register-confirmation/page.tsx
+++ b/frontend/src/app/register-confirmation/page.tsx
@@ -95,6 +95,13 @@ export default function RegisterConfirmationPage() {
 
     try {
       const saitamaAppIdValue = formData.saitamaAppId && formData.saitamaAppId.trim() !== '' ? formData.saitamaAppId.trim() : undefined;
+      
+      // セッションストレージから紹介者IDを取得
+      const referrerUserId = typeof window !== 'undefined' 
+        ? sessionStorage.getItem('referrerUserId') 
+        : null;
+      
+      console.log('🔍 [register-confirmation] referrerUserId from sessionStorage:', referrerUserId);
 
       // バックエンドAPIに登録リクエストを送信
       const response = await fetch('/api/auth/register', {
@@ -114,6 +121,8 @@ export default function RegisterConfirmationPage() {
           phone: formData.phone,
           // 空文字列の場合はundefinedとして送信しない
           saitamaAppId: saitamaAppIdValue,
+          // 紹介者IDを追加
+          referrerUserId: referrerUserId && referrerUserId.trim() !== '' ? referrerUserId.trim() : undefined,
           token: token,
         }),
       })
@@ -126,6 +135,7 @@ export default function RegisterConfirmationPage() {
 
         // 登録成功後はセッションストレージをクリア
         sessionStorage.removeItem('registerFormData')
+        sessionStorage.removeItem('referrerUserId')
 
         // さいたま市アプリ連携でポイント付与があった場合はモーダルを表示
         if (result.pointsGranted) {

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -19,12 +19,19 @@ export default function RegisterPage() {
       const urlParams = new URLSearchParams(window.location.search)
       const email = urlParams.get('email') || undefined
       const token = urlParams.get('token') || undefined
+      const ref = urlParams.get('ref') // 紹介者IDを取得
       const isEdit = urlParams.get('edit') === 'true'
 
       // トークンが存在しない場合はメール登録画面にリダイレクト
       if (!token || token.trim() === '') {
         router.push('/email-registration')
         return
+      }
+
+      // URLパラメータから紹介者IDを取得してセッションストレージに保存
+      if (ref) {
+        sessionStorage.setItem('referrerUserId', ref)
+        console.log('🔍 [register] referrerUserId saved to sessionStorage from URL:', ref)
       }
 
       setSearchParams({

--- a/frontend/src/components/organisms/MypageContainer.tsx
+++ b/frontend/src/components/organisms/MypageContainer.tsx
@@ -2,7 +2,7 @@
 
 import React, { useMemo } from "react"
 import Image from "next/image"
-import { SquarePen, Crown, RefreshCw, Mail, Lock, LogOut, History, CreditCard } from "lucide-react"
+import { SquarePen, Crown, RefreshCw, Mail, Lock, LogOut, History, CreditCard, Share2, Copy, Check } from "lucide-react"
 import { User } from "lucide-react"
 import { Logo } from "../atoms/Logo"
 import { getNextRankInfo, getMonthsToNextRank, RANK_INFO } from "@/utils/rank-calculator"
@@ -142,6 +142,76 @@ const ProfileCard = React.memo(({ user, onEditProfile }: { user?: UserType, onEd
   );
 })
 ProfileCard.displayName = 'ProfileCard'
+
+// 紹介用URLカードコンポーネント
+const ReferrerUrlCard = React.memo(({ user }: { user?: UserType }) => {
+  const [copied, setCopied] = React.useState(false)
+  
+  if (!user) {
+    return null
+  }
+
+  // 紹介用URLを生成（APIから取得できない場合はフロントエンドで生成）
+  const referrerUrl = user.referrerUrl || (typeof window !== 'undefined' 
+    ? `${window.location.origin}/email-registration?ref=${user.id}` 
+    : null)
+
+  const handleCopy = async () => {
+    if (!referrerUrl) return
+
+    try {
+      await navigator.clipboard.writeText(referrerUrl)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch (error) {
+      console.error('コピーに失敗しました:', error)
+    }
+  }
+
+  if (!referrerUrl) {
+    return null
+  }
+
+  return (
+    <div className="bg-white rounded-2xl border border-green-200 p-6">
+      <div className="flex items-center gap-3 mb-4">
+        <div className="w-8 h-8 bg-green-100 rounded-lg flex items-center justify-center">
+          <Share2 className="w-5 h-5 text-green-600" />
+        </div>
+        <span className="text-lg font-bold text-gray-500">友達紹介</span>
+      </div>
+
+      <div className="space-y-3">
+        <div>
+          <label className="text-sm text-gray-600 mb-2 block">紹介用URL</label>
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              readOnly
+              value={referrerUrl}
+              className="flex-1 px-3 py-2 bg-gray-50 border border-gray-300 rounded-lg text-sm text-gray-700 focus:outline-none"
+            />
+            <button
+              onClick={handleCopy}
+              className="p-2 bg-green-600 hover:bg-green-700 text-white rounded-lg transition-colors flex items-center justify-center"
+              title={copied ? 'コピーしました' : 'クリップボードにコピー'}
+            >
+              {copied ? (
+                <Check className="w-5 h-5" />
+              ) : (
+                <Copy className="w-5 h-5" />
+              )}
+            </button>
+          </div>
+        </div>
+        <p className="text-xs text-gray-500">
+          このURLを友達に共有すると、友達が登録した際に紹介として記録されます。
+        </p>
+      </div>
+    </div>
+  );
+})
+ReferrerUrlCard.displayName = 'ReferrerUrlCard'
 
 // ランク画像コンポーネント
 const RankImage = React.memo(({ rank, alt, className }: { rank: string, alt: string, className: string }) => (
@@ -439,6 +509,10 @@ export const MyPageContainer = React.memo(function MyPageContainer({
         <StaggeredContainer staggerDelay={100}>
           <FadeInComponent delay={200}>
             <ProfileCard user={user} onEditProfile={onEditProfile} />
+          </FadeInComponent>
+
+          <FadeInComponent delay={250}>
+            <ReferrerUrlCard user={user} />
           </FadeInComponent>
 
           {/* TODO: 将来的にメンバーランク機能を再実装する可能性があるためコメントアウト */}

--- a/frontend/src/components/templates/HomeLayout.tsx
+++ b/frontend/src/components/templates/HomeLayout.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { useEffect, useRef, useState } from "react"
-import Image from "next/image"
 import { HomeContainer } from "../organisms/HomeContainer"
 import { LoginLayout } from "./LoginLayout"
 import { EmailRegistrationContainer } from "../organisms/EmailRegistrationContainer"

--- a/frontend/src/hooks/useEmailRegistration.ts
+++ b/frontend/src/hooks/useEmailRegistration.ts
@@ -53,7 +53,31 @@ export function useEmailRegistration(): UseEmailRegistrationReturn {
     setErrorMessage('')
 
     try {
-      await preRegister(data.email, data.campaignCode)
+      // セッションストレージから紹介者IDを取得
+      const referrerUserId = typeof window !== 'undefined'
+        ? sessionStorage.getItem('referrerUserId')
+        : null;
+      
+      console.log('🔍 [useEmailRegistration] referrerUserId from sessionStorage:', referrerUserId);
+      console.log('🔍 [useEmailRegistration] sessionStorage keys:', typeof window !== 'undefined' ? Object.keys(sessionStorage) : []);
+      console.log('🔍 [useEmailRegistration] Current URL:', typeof window !== 'undefined' ? window.location.href : 'N/A');
+      console.log('🔍 [useEmailRegistration] URL search params:', typeof window !== 'undefined' ? new URLSearchParams(window.location.search).toString() : 'N/A');
+
+      // 紹介者IDを含めてpreRegisterを呼び出し
+      const registrationData: UserRegistrationRequest = {
+        email: data.email,
+        campaignCode: data.campaignCode,
+        ...(referrerUserId && referrerUserId.trim() !== '' ? { referrerUserId: referrerUserId.trim() } : {}),
+      };
+
+      console.log('🔍 [useEmailRegistration] registrationData:', {
+        email: registrationData.email,
+        campaignCode: registrationData.campaignCode,
+        referrerUserId: referrerUserId || undefined,
+        hasReferrerUserId: !!referrerUserId,
+      });
+
+      await preRegister(registrationData.email, registrationData.campaignCode, referrerUserId || undefined)
       // メールアドレスを保存
       setLastEmail(data.email)
       // 送信完了画面に遷移
@@ -84,7 +108,12 @@ export function useEmailRegistration(): UseEmailRegistrationReturn {
     setSuccessMessage('')
 
     try {
-      await preRegister(lastEmail)
+      // セッションストレージから紹介者IDを取得
+      const referrerUserId = typeof window !== 'undefined'
+        ? sessionStorage.getItem('referrerUserId')
+        : null;
+
+      await preRegister(lastEmail, undefined, referrerUserId || undefined)
       // 成功メッセージを表示（画面は complete のまま）
       setSuccessMessage('認証メールを再送信しました')
       

--- a/frontend/src/hooks/useInfiniteStores.ts
+++ b/frontend/src/hooks/useInfiniteStores.ts
@@ -216,9 +216,28 @@ export function useInfiniteStores(options: UseInfiniteStoresOptions = {}): UseIn
         console.log('[useInfiniteStores] Response status:', res.status)
         
         if (!res.ok) {
-          const data = await res.json().catch(() => ({}))
-          const message = data?.error?.message || '店舗情報の取得に失敗しました'
-          console.error('[useInfiniteStores] Response error:', data)
+          let data: any = {}
+          try {
+            const contentType = res.headers.get('content-type')
+            if (contentType && contentType.includes('application/json')) {
+              data = await res.json()
+            } else {
+              const text = await res.text()
+              console.error('[useInfiniteStores] Response is not JSON:', text.substring(0, 200))
+              data = { message: text.substring(0, 200) }
+            }
+          } catch (parseError) {
+            console.error('[useInfiniteStores] Failed to parse error response:', parseError)
+            data = { message: 'エラーレスポンスの解析に失敗しました' }
+          }
+          
+          const message = data?.error?.message || data?.message || `店舗情報の取得に失敗しました (${res.status})`
+          console.error('[useInfiniteStores] Response error:', {
+            status: res.status,
+            statusText: res.statusText,
+            data,
+            message,
+          })
           throw new Error(message)
         }
 

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -35,7 +35,7 @@ export class ApiClient {
   ): Promise<ApiResponse<T>> {
     const {
       requireAuth = true,
-      autoRefresh = true,
+      autoRefresh: _autoRefresh = true,
       headers = {},
       ...fetchOptions
     } = options;
@@ -164,18 +164,30 @@ export interface PreRegisterResponse {
  */
 export async function preRegister(
   email: string,
-  campaignCode?: string
+  campaignCode?: string,
+  referrerUserId?: string
 ): Promise<PreRegisterResponse> {
   try {
+    const requestBody = {
+      email,
+      campaignCode,
+      ...(referrerUserId && referrerUserId.trim() !== '' ? { referrerUserId: referrerUserId.trim() } : {}),
+    };
+
+    console.log('🔍 [api-client] preRegister called with:', {
+      email,
+      campaignCode,
+      referrerUserId,
+      hasReferrerUserId: !!referrerUserId,
+      requestBody,
+    });
+
     const response = await fetch('/api/auth/pre-register', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({
-        email,
-        campaignCode,
-      }),
+      body: JSON.stringify(requestBody),
     })
 
     if (!response.ok) {

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -23,6 +23,7 @@ export interface User {
     paygentCustomerId: string
     paygentCustomerCardId: string
   } | null
+  referrerUrl?: string | null
 }
 
 /**


### PR DESCRIPTION
## 概要
友達紹介機能を実装し、リンター警告を修正しました。

## 変更内容

### 友達紹介機能の実装
- 紹介URLからメール登録時に`referrerUserId`を`sessionStorage`に保存
- `pre-register` APIに`referrerUserId`を渡す処理を追加
- メール認証URLから`referrerUserId`を引き継ぐ処理を追加
- マイページに紹介URL表示とクリップボードコピー機能を追加
- Next.js 15対応: `params`の`await`処理を追加（`[token]`, `[shopId]`, `[customer_id]`ルート）

### エラーハンドリング改善
- `useInfiniteStores`: Content-Typeチェックを追加し、非JSONレスポンスを適切に処理
- `/api/shops`: 非JSONレスポンスの処理を改善

### リンター修正
- `HomeLayout.tsx`: 未使用の`Image`インポートを削除
- `api-client.ts`: 未使用の`autoRefresh`変数にアンダースコアプレフィックスを追加

## 関連する変更
- API側の友達紹介機能実装と連携
- スキーマパッケージの`referrerUserId`フィールド追加に対応

## テスト
- ✅ リンターチェック: エラー0件、警告0件
- ✅ ビルドチェック: 成功（34ページ生成）