### PR TITLE
fix: 新規登録URLのセキュリティ脆弱性対応

### DIFF
--- a/frontend/env.example
+++ b/frontend/env.example
@@ -68,6 +68,15 @@ NEXT_PUBLIC_MYPAGE_SHOW_WITHDRAWAL=true
 NEXT_PUBLIC_RESTRICT_TOP_PAGE_ACCESS=false
 
 # ==========================================
+# セッション暗号化
+# ==========================================
+
+# セッションデータ暗号化用シークレットキー（32文字以上推奨）
+# 本番環境では必ず強力なランダム文字列を設定してください
+# 生成例: openssl rand -base64 32
+SESSION_SECRET=your-secure-session-secret-key-here-min-32-chars
+
+# ==========================================
 # Next.js設定
 # ==========================================
 

--- a/frontend/src/app/api/auth/register/session/route.ts
+++ b/frontend/src/app/api/auth/register/session/route.ts
@@ -1,0 +1,235 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from 'crypto'
+
+/**
+ * 登録セッションデータをサーバーサイドで管理するAPI
+ * sessionStorageの代わりにhttpOnly Cookieを使用してセキュリティを向上
+ */
+
+const COOKIE_NAME = 'register_session'
+const ALGORITHM = 'aes-256-gcm'
+const IV_LENGTH = 16
+const AUTH_TAG_LENGTH = 16
+const SALT_LENGTH = 16
+
+// セッション有効期限（30分）
+const SESSION_MAX_AGE = 30 * 60
+
+/**
+ * 暗号化キーを生成
+ */
+function getEncryptionKey(salt: Buffer): Buffer {
+  const secret = process.env.SESSION_SECRET || 'default-dev-secret-key-change-in-production'
+  return scryptSync(secret, salt, 32)
+}
+
+/**
+ * データを暗号化
+ */
+function encrypt(data: string): string {
+  const salt = randomBytes(SALT_LENGTH)
+  const key = getEncryptionKey(salt)
+  const iv = randomBytes(IV_LENGTH)
+  const cipher = createCipheriv(ALGORITHM, key, iv)
+  
+  let encrypted = cipher.update(data, 'utf8', 'hex')
+  encrypted += cipher.final('hex')
+  const authTag = cipher.getAuthTag()
+  
+  // salt + iv + authTag + encrypted data を結合
+  return salt.toString('hex') + iv.toString('hex') + authTag.toString('hex') + encrypted
+}
+
+/**
+ * データを復号化
+ */
+function decrypt(encryptedData: string): string {
+  // salt + iv + authTag + encrypted data を分離
+  const salt = Buffer.from(encryptedData.slice(0, SALT_LENGTH * 2), 'hex')
+  const iv = Buffer.from(encryptedData.slice(SALT_LENGTH * 2, SALT_LENGTH * 2 + IV_LENGTH * 2), 'hex')
+  const authTag = Buffer.from(encryptedData.slice(SALT_LENGTH * 2 + IV_LENGTH * 2, SALT_LENGTH * 2 + IV_LENGTH * 2 + AUTH_TAG_LENGTH * 2), 'hex')
+  const encrypted = encryptedData.slice(SALT_LENGTH * 2 + IV_LENGTH * 2 + AUTH_TAG_LENGTH * 2)
+  
+  const key = getEncryptionKey(salt)
+  const decipher = createDecipheriv(ALGORITHM, key, iv)
+  decipher.setAuthTag(authTag)
+  
+  let decrypted = decipher.update(encrypted, 'hex', 'utf8')
+  decrypted += decipher.final('utf8')
+  
+  return decrypted
+}
+
+/**
+ * セッションデータの型定義
+ */
+interface RegisterSessionData {
+  registerEmail?: string
+  registerFormData?: Record<string, unknown>
+  referrerUserId?: string
+  userEmail?: string
+  editFormData?: Record<string, unknown>
+}
+
+/**
+ * GET: セッションデータを取得
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const sessionCookie = request.cookies.get(COOKIE_NAME)
+    
+    if (!sessionCookie?.value) {
+      return NextResponse.json({ data: null })
+    }
+    
+    try {
+      const decrypted = decrypt(sessionCookie.value)
+      const data = JSON.parse(decrypted) as RegisterSessionData
+      return NextResponse.json({ data })
+    } catch {
+      // 復号化に失敗した場合は空のデータを返す
+      return NextResponse.json({ data: null })
+    }
+  } catch (error) {
+    console.error('Session GET error:', error)
+    return NextResponse.json(
+      { error: { code: 'INTERNAL_ERROR', message: '内部エラーが発生しました' } },
+      { status: 500 }
+    )
+  }
+}
+
+/**
+ * POST: セッションデータを保存（部分更新）
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const { key, value } = body as { key: keyof RegisterSessionData; value: unknown }
+    
+    if (!key) {
+      return NextResponse.json(
+        { error: { code: 'MISSING_KEY', message: 'キーが必要です' } },
+        { status: 400 }
+      )
+    }
+    
+    // 既存のセッションデータを取得
+    let existingData: RegisterSessionData = {}
+    const sessionCookie = request.cookies.get(COOKIE_NAME)
+    
+    if (sessionCookie?.value) {
+      try {
+        const decrypted = decrypt(sessionCookie.value)
+        existingData = JSON.parse(decrypted)
+      } catch {
+        // 復号化に失敗した場合は新しいセッションを開始
+        existingData = {}
+      }
+    }
+    
+    // データを更新
+    if (value === null || value === undefined) {
+      delete existingData[key]
+    } else {
+      existingData[key] = value as RegisterSessionData[typeof key]
+    }
+    
+    // 暗号化してCookieに保存
+    const encrypted = encrypt(JSON.stringify(existingData))
+    
+    const isSecure = (() => {
+      try { return new URL(request.url).protocol === 'https:' } catch { return process.env.NODE_ENV === 'production' }
+    })()
+    
+    const response = NextResponse.json({ success: true })
+    response.cookies.set(COOKIE_NAME, encrypted, {
+      httpOnly: true,
+      secure: isSecure,
+      sameSite: 'strict',
+      path: '/',
+      maxAge: SESSION_MAX_AGE,
+    })
+    
+    return response
+  } catch (error) {
+    console.error('Session POST error:', error)
+    return NextResponse.json(
+      { error: { code: 'INTERNAL_ERROR', message: '内部エラーが発生しました' } },
+      { status: 500 }
+    )
+  }
+}
+
+/**
+ * DELETE: セッションデータを削除（特定のキーまたは全体）
+ */
+export async function DELETE(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url)
+    const key = searchParams.get('key') as keyof RegisterSessionData | null
+    
+    const isSecure = (() => {
+      try { return new URL(request.url).protocol === 'https:' } catch { return process.env.NODE_ENV === 'production' }
+    })()
+    
+    if (key) {
+      // 特定のキーのみ削除
+      let existingData: RegisterSessionData = {}
+      const sessionCookie = request.cookies.get(COOKIE_NAME)
+      
+      if (sessionCookie?.value) {
+        try {
+          const decrypted = decrypt(sessionCookie.value)
+          existingData = JSON.parse(decrypted)
+          delete existingData[key]
+        } catch {
+          existingData = {}
+        }
+      }
+      
+      const response = NextResponse.json({ success: true })
+      
+      if (Object.keys(existingData).length > 0) {
+        const encrypted = encrypt(JSON.stringify(existingData))
+        response.cookies.set(COOKIE_NAME, encrypted, {
+          httpOnly: true,
+          secure: isSecure,
+          sameSite: 'strict',
+          path: '/',
+          maxAge: SESSION_MAX_AGE,
+        })
+      } else {
+        // データが空になった場合はCookieを削除
+        response.cookies.set(COOKIE_NAME, '', {
+          httpOnly: true,
+          secure: isSecure,
+          sameSite: 'strict',
+          path: '/',
+          maxAge: 0,
+        })
+      }
+      
+      return response
+    } else {
+      // 全体を削除
+      const response = NextResponse.json({ success: true })
+      response.cookies.set(COOKIE_NAME, '', {
+        httpOnly: true,
+        secure: isSecure,
+        sameSite: 'strict',
+        path: '/',
+        maxAge: 0,
+      })
+      
+      return response
+    }
+  } catch (error) {
+    console.error('Session DELETE error:', error)
+    return NextResponse.json(
+      { error: { code: 'INTERNAL_ERROR', message: '内部エラーが発生しました' } },
+      { status: 500 }
+    )
+  }
+}
+

--- a/frontend/src/app/api/auth/register/token-info/route.ts
+++ b/frontend/src/app/api/auth/register/token-info/route.ts
@@ -4,11 +4,12 @@ const API_BASE_URL = process.env.API_BASE_URL || 'http://localhost:3002'
 
 /**
  * トークンからメールアドレスを取得するAPIプロキシ
- * URLパラメータにメールアドレスを含めないためのセキュリティ改善
+ * POSTメソッドを使用してトークンをボディで送信（プロキシログへの記録を防止）
  */
-export async function GET(request: NextRequest) {
+export async function POST(request: NextRequest) {
     try {
-        const token = request.nextUrl.searchParams.get('token')
+        const body = await request.json()
+        const { token } = body
 
         if (!token) {
             return NextResponse.json(
@@ -17,12 +18,13 @@ export async function GET(request: NextRequest) {
             )
         }
 
-        // バックエンドAPIにプロキシ
-        const response = await fetch(`${API_BASE_URL}/api/v1/register/token-info?token=${encodeURIComponent(token)}`, {
-            method: 'GET',
+        // バックエンドAPIにPOSTでプロキシ（トークンをボディで送信）
+        const response = await fetch(`${API_BASE_URL}/api/v1/register/token-info`, {
+            method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
             },
+            body: JSON.stringify({ token }),
         })
 
         if (!response.ok) {

--- a/frontend/src/app/api/auth/register/verify/[token]/route.ts
+++ b/frontend/src/app/api/auth/register/verify/[token]/route.ts
@@ -14,13 +14,14 @@ export async function GET(
         }
 
         // トークンはUUIDのみで、メールアドレスなどの個人情報は含まれない（セキュリティ改善）
-        // バックエンドAPIでトークンを検証
+        // バックエンドAPIでトークンを検証（POSTメソッドでトークンをボディ送信）
         try {
-            const response = await fetch(`${API_BASE_URL}/api/v1/register/token-info?token=${encodeURIComponent(token)}`, {
-                method: 'GET',
+            const response = await fetch(`${API_BASE_URL}/api/v1/register/token-info`, {
+                method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
                 },
+                body: JSON.stringify({ token }),
             })
 
             if (!response.ok) {

--- a/frontend/src/app/email-registration/page.tsx
+++ b/frontend/src/app/email-registration/page.tsx
@@ -4,6 +4,7 @@ import { Suspense, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { EmailRegistrationContainer } from '@/components/organisms/EmailRegistrationContainer'
 import { useEmailRegistration } from '@/hooks/useEmailRegistration'
+import { setRegisterSessionItem } from '@/lib/register-session'
 
 function EmailRegistrationContent() {
   const router = useRouter()
@@ -17,20 +18,18 @@ function EmailRegistrationContent() {
     handleResend,
   } = useEmailRegistration()
 
-  // URLパラメータから紹介者IDを取得してセッションストレージに保存
+  // URLパラメータから紹介者IDを取得してサーバーサイドセッションに保存
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      const urlParams = new URLSearchParams(window.location.search)
-      const ref = urlParams.get('ref')
-      if (ref) {
-        sessionStorage.setItem('referrerUserId', ref)
-        // 保存後に確認
-        const saved = sessionStorage.getItem('referrerUserId')
-      } else {
-        // 既存の値を確認
-        const existing = sessionStorage.getItem('referrerUserId')
+    const saveReferrer = async () => {
+      if (typeof window !== 'undefined') {
+        const urlParams = new URLSearchParams(window.location.search)
+        const ref = urlParams.get('ref')
+        if (ref) {
+          await setRegisterSessionItem('referrerUserId', ref)
+        }
       }
     }
+    saveReferrer()
   }, [])
 
   const handleBack = () => router.push('/')

--- a/frontend/src/app/plan-registration/page.tsx
+++ b/frontend/src/app/plan-registration/page.tsx
@@ -12,6 +12,7 @@ import {
   PlanListResponseSchema
 } from '@hv-development/schemas'
 import type { PayPayPaymentRequest } from '@hv-development/schemas'
+import { getRegisterSessionItem, removeRegisterSessionItem } from '@/lib/register-session'
 
 export default function PlanRegistrationPage() {
   const [isLoading, setIsLoading] = useState(false)
@@ -94,16 +95,21 @@ export default function PlanRegistrationPage() {
   // クライアントサイドでのみ searchParams を取得
   useEffect(() => {
     setIsClient(true)
-    if (typeof window !== 'undefined') {
+    const initializePage = async () => {
+      if (typeof window === 'undefined') return
+
       const urlParams = new URLSearchParams(window.location.search)
       const saitamaAppLinkedParam = urlParams.get('saitamaAppLinked')
       const refreshParam = urlParams.get('refresh')
       const paymentMethodChangeParam = urlParams.get('payment-method-change')
 
-      // セッションストレージからメールアドレスを取得（一時的に使用）
-      const sessionEmail = sessionStorage.getItem('userEmail')
-      if (sessionEmail) {
-        setEmail(sessionEmail)
+      // サーバーサイドセッションからメールアドレスを取得（登録フローからの遷移用）
+      // セキュリティ改善：sessionStorageの代わりにhttpOnly Cookieベースのセッションを使用
+      const serverSessionEmail = await getRegisterSessionItem<string>('userEmail')
+      if (serverSessionEmail) {
+        setEmail(serverSessionEmail)
+        // 使用後にサーバーサイドセッションからクリア
+        await removeRegisterSessionItem('userEmail')
       }
 
       // 支払い方法変更のみの場合はフラグを設定
@@ -121,10 +127,11 @@ export default function PlanRegistrationPage() {
         fetchUserInfo()
       } else {
         // 常にユーザー情報を取得してメールアドレスを確実に取得する
-        // （sessionStorageは一時的なものなので、APIから取得した方が確実）
+        // （APIから取得した方が確実）
         fetchUserInfo()
       }
     }
+    initializePage()
   }, [fetchUserInfo])
 
   // ページがフォーカスされた時にユーザー情報を再取得（戻るボタンで戻ってきた時など）

--- a/frontend/src/app/register-confirmation/page.tsx
+++ b/frontend/src/app/register-confirmation/page.tsx
@@ -1,11 +1,16 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useRouter } from 'next/navigation'
 import { RegisterConfirmationContainer } from '@/components/organisms/RegisterConfirmationContainer'
 import { UserRegistrationComplete } from "@hv-development/schemas"
 import { Modal } from '@/components/atoms/Modal'
 import { Button } from '@/components/atoms/Button'
+import { 
+  getRegisterSession, 
+  setRegisterSessionItem, 
+  clearRegisterSession 
+} from '@/lib/register-session'
 
 export default function RegisterConfirmationPage() {
   const [isLoading, setIsLoading] = useState(false)
@@ -19,7 +24,10 @@ export default function RegisterConfirmationPage() {
   const [pointsGranted, setPointsGranted] = useState<number | null>(null)
   const [shopId, setShopId] = useState<string | undefined>(undefined)
   const [error, setError] = useState<string | null>(null)
+  const [referrerUserId, setReferrerUserId] = useState<string | null>(null)
   const router = useRouter()
+  // セッションデータを保持するref（handleRegisterで使用）
+  const sessionDataRef = useRef<{ referrerUserId?: string } | null>(null)
 
   // クライアントサイドでのみ searchParams を取得
   useEffect(() => {
@@ -43,34 +51,48 @@ export default function RegisterConfirmationPage() {
 
       setToken(tokenParam)
 
-      // まずsessionStorageからフォームデータを取得
-      const storedData = sessionStorage.getItem('registerFormData')
+      // サーバーサイドセッションからデータを取得
+      const sessionData = await getRegisterSession()
+      
+      // 紹介者IDをrefに保存（handleRegisterで使用）
+      if (sessionData?.referrerUserId) {
+        sessionDataRef.current = { referrerUserId: sessionData.referrerUserId }
+        setReferrerUserId(sessionData.referrerUserId)
+      }
+      
+      const storedData = sessionData?.registerFormData
 
       if (storedData) {
-        // sessionStorageにデータがある場合（通常フロー）
+        // サーバーサイドセッションにデータがある場合（通常フロー）
         try {
-          const parsedData = JSON.parse(storedData) as UserRegistrationComplete
+          const parsedData = storedData as UserRegistrationComplete
           // shop_idがURLパラメータにある場合は上書き
           if (shopIdParam) {
             parsedData.shopId = shopIdParam
           }
           setFormData(parsedData)
 
-          // メールアドレスをセッションストレージから取得（セキュリティ改善：URLパラメータから削除）
-          const storedEmail = sessionStorage.getItem('registerEmail')
+          // メールアドレスをサーバーサイドセッションから取得
+          const storedEmail = sessionData?.registerEmail
           if (storedEmail) {
             setEmail(storedEmail)
             setIsLoadingEmail(false)
             return
           }
 
-          // セッションストレージにメールアドレスがない場合、APIから取得
+          // サーバーサイドセッションにメールアドレスがない場合、APIから取得（POSTでトークンをボディ送信）
           try {
-            const response = await fetch(`/api/auth/register/token-info?token=${encodeURIComponent(tokenParam)}`)
+            const response = await fetch('/api/auth/register/token-info', {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              body: JSON.stringify({ token: tokenParam }),
+            })
             if (response.ok) {
               const data = await response.json()
               setEmail(data.email)
-              sessionStorage.setItem('registerEmail', data.email)
+              await setRegisterSessionItem('registerEmail', data.email)
             } else {
               throw new Error('Failed to fetch email')
             }
@@ -85,14 +107,20 @@ export default function RegisterConfirmationPage() {
           setIsLoadingEmail(false)
           return
         } catch (err) {
-          console.error('sessionStorage parse error:', err)
+          console.error('Session data parse error:', err)
           // パースエラーの場合は次の処理へ
         }
       }
 
-      // sessionStorageがない場合、APIからメールアドレスを取得して登録画面に戻す
+      // サーバーサイドセッションがない場合、APIからメールアドレスを取得して登録画面に戻す（POSTでトークンをボディ送信）
       try {
-        const response = await fetch(`/api/auth/register/token-info?token=${encodeURIComponent(tokenParam)}`)
+        const response = await fetch('/api/auth/register/token-info', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ token: tokenParam }),
+        })
         
         if (!response.ok) {
           const errorData = await response.json().catch(() => ({}))
@@ -129,11 +157,8 @@ export default function RegisterConfirmationPage() {
     try {
       const saitamaAppIdValue = formData.saitamaAppId && formData.saitamaAppId.trim() !== '' ? formData.saitamaAppId.trim() : undefined;
       
-      // セッションストレージから紹介者IDを取得
-      const referrerUserId = typeof window !== 'undefined' 
-        ? sessionStorage.getItem('referrerUserId') 
-        : null;
-      
+      // サーバーサイドセッションから取得した紹介者IDを使用
+      const referrerUserIdValue = sessionDataRef.current?.referrerUserId || referrerUserId;
 
       // バックエンドAPIに登録リクエストを送信
       const response = await fetch('/api/auth/register', {
@@ -154,7 +179,7 @@ export default function RegisterConfirmationPage() {
           // 空文字列の場合はundefinedとして送信しない
           saitamaAppId: saitamaAppIdValue,
           // 紹介者IDを追加
-          referrerUserId: referrerUserId && referrerUserId.trim() !== '' ? referrerUserId.trim() : undefined,
+          referrerUserId: referrerUserIdValue && referrerUserIdValue.trim() !== '' ? referrerUserIdValue.trim() : undefined,
           token: token,
           shopId: shopId,
         }),
@@ -166,10 +191,8 @@ export default function RegisterConfirmationPage() {
         // Cookieベースの認証のみを使用（localStorageは廃止）
         // トークンはサーバー側でCookieに設定されるため、フロントエンドでの保存は不要
 
-        // 登録成功後はセッションストレージをクリア
-        sessionStorage.removeItem('registerFormData')
-        sessionStorage.removeItem('referrerUserId')
-        sessionStorage.removeItem('registerEmail')
+        // 登録成功後はサーバーサイドセッションをクリア
+        await clearRegisterSession()
 
         // さいたま市アプリ連携が失敗した場合（ポイント付与API失敗）
         if (result.saitamaAppLinkFailed) {
@@ -182,8 +205,8 @@ export default function RegisterConfirmationPage() {
           setPointsGranted(result.pointsGranted)
           setShowSuccessModal(true)
         } else {
-          // ポイント付与がない場合は直接プラン登録画面に遷移（セッションストレージにメールアドレスを保存）
-          sessionStorage.setItem('userEmail', email)
+          // ポイント付与がない場合は直接プラン登録画面に遷移（サーバーサイドセッションにメールアドレスを保存）
+          await setRegisterSessionItem('userEmail', email)
           // window.location.hrefを使用して強制的に遷移
           if (typeof window !== 'undefined') {
             window.location.href = '/plan-registration'
@@ -210,10 +233,10 @@ export default function RegisterConfirmationPage() {
     }
   }
 
-  const handleEdit = () => {
-    // フォームデータをsessionStorageに保存してから登録画面に戻る（emailパラメータは含めない - セキュリティ改善）
+  const handleEdit = async () => {
+    // フォームデータをサーバーサイドセッションに保存してから登録画面に戻る（emailパラメータは含めない - セキュリティ改善）
     if (formData) {
-      sessionStorage.setItem('editFormData', JSON.stringify(formData))
+      await setRegisterSessionItem('editFormData', formData)
     }
     const shopIdParam = formData?.shopId ? `&shop_id=${encodeURIComponent(formData?.shopId)}` : ''
     router.push(`/register?token=${encodeURIComponent(token)}&edit=true${shopIdParam}`)
@@ -221,10 +244,10 @@ export default function RegisterConfirmationPage() {
 
   const handleLogoClick = () => router.push('/')
 
-  const handleModalClose = () => {
+  const handleModalClose = async () => {
     setShowSuccessModal(false)
-    // モーダルを閉じた後、プラン登録画面に遷移（セッションストレージにメールアドレスを保存）
-    sessionStorage.setItem('userEmail', email)
+    // モーダルを閉じた後、プラン登録画面に遷移（サーバーサイドセッションにメールアドレスを保存）
+    await setRegisterSessionItem('userEmail', email)
     // window.location.hrefを使用して強制的に遷移
     if (typeof window !== 'undefined') {
       window.location.href = '/plan-registration?saitamaAppLinked=true'
@@ -233,10 +256,10 @@ export default function RegisterConfirmationPage() {
     }
   }
 
-  const handleSaitamaFailedModalClose = () => {
+  const handleSaitamaFailedModalClose = async () => {
     setShowSaitamaFailedModal(false)
     // さいたま市アプリ連携なしでプラン登録画面に遷移
-    sessionStorage.setItem('userEmail', email)
+    await setRegisterSessionItem('userEmail', email)
     if (typeof window !== 'undefined') {
       window.location.href = '/plan-registration'
     } else {

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -4,6 +4,11 @@ import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { RegisterContainer } from '@/components/organisms/RegisterContainer'
 import { UserRegistrationComplete } from "@hv-development/schemas"
+import { 
+  getRegisterSession, 
+  setRegisterSessionItem, 
+  removeRegisterSessionItem 
+} from '@/lib/register-session'
 
 export default function RegisterPage() {
   const [isLoading, setIsLoading] = useState(false)
@@ -38,25 +43,26 @@ export default function RegisterPage() {
       setToken(tokenParam)
       setShopId(shop_id)
 
-      // URLパラメータから紹介者IDを取得してセッションストレージに保存
+      // URLパラメータから紹介者IDを取得してサーバーサイドセッションに保存
       if (ref) {
-        sessionStorage.setItem('referrerUserId', ref)
+        await setRegisterSessionItem('referrerUserId', ref)
       }
 
       // 編集モードの場合、保存されたフォームデータを取得
       if (isEdit) {
-        const savedData = sessionStorage.getItem('registerFormData')
+        const sessionData = await getRegisterSession()
+        const savedData = sessionData?.registerFormData
         if (savedData) {
           try {
-            const parsedData = JSON.parse(savedData) as UserRegistrationComplete
+            const parsedData = savedData as UserRegistrationComplete
             setInitialFormData(parsedData)
-            sessionStorage.removeItem('registerFormData')
+            await removeRegisterSessionItem('registerFormData')
           } catch {
             // エラーを無視
           }
         }
-        // 編集モードの場合、セッションストレージからメールアドレスを取得
-        const savedEmail = sessionStorage.getItem('registerEmail')
+        // 編集モードの場合、サーバーサイドセッションからメールアドレスを取得
+        const savedEmail = sessionData?.registerEmail
         if (savedEmail) {
           setEmail(savedEmail)
           setIsLoadingEmail(false)
@@ -64,9 +70,15 @@ export default function RegisterPage() {
         }
       }
 
-      // トークンからメールアドレスを取得（セキュリティ改善：URLパラメータにメールアドレスを含めない）
+      // トークンからメールアドレスを取得（セキュリティ改善：POSTでトークンをボディ送信）
       try {
-        const response = await fetch(`/api/auth/register/token-info?token=${encodeURIComponent(tokenParam)}`)
+        const response = await fetch('/api/auth/register/token-info', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ token: tokenParam }),
+        })
         
         if (!response.ok) {
           const errorData = await response.json().catch(() => ({}))
@@ -81,8 +93,8 @@ export default function RegisterPage() {
 
         const data = await response.json()
         setEmail(data.email)
-        // セッションストレージにメールアドレスを保存（確認画面での復元用）
-        sessionStorage.setItem('registerEmail', data.email)
+        // サーバーサイドセッションにメールアドレスを保存（確認画面での復元用）
+        await setRegisterSessionItem('registerEmail', data.email)
       } catch {
         setError('エラーが発生しました。再度お試しください。')
         setTimeout(() => router.push('/email-registration'), 3000)
@@ -103,8 +115,8 @@ export default function RegisterPage() {
       shop_id: shopId || undefined,
     }
 
-    // フォームデータをセッションストレージに保存
-    sessionStorage.setItem('registerFormData', JSON.stringify(dataWithShopId))
+    // フォームデータをサーバーサイドセッションに保存
+    await setRegisterSessionItem('registerFormData', dataWithShopId)
 
     // 確認画面に遷移（emailパラメータを削除 - セキュリティ改善）
     const shopIdParam = shopId ? `&shop_id=${encodeURIComponent(shopId)}` : ''

--- a/frontend/src/components/organisms/RegisterForm.tsx
+++ b/frontend/src/components/organisms/RegisterForm.tsx
@@ -298,19 +298,6 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({
 
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
-      {/* メールアドレス表示 */}
-      {email && (
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-2">
-            メールアドレス
-          </label>
-          <div className="px-4 py-3 bg-gray-50 border border-gray-200 rounded-lg text-gray-700">
-            {email}
-          </div>
-          <p className="mt-1 text-xs text-gray-500">※認証済みのメールアドレスです</p>
-        </div>
-      )}
-
       {/* ニックネーム */}
       <Input
         type="text"

--- a/frontend/src/lib/register-session.ts
+++ b/frontend/src/lib/register-session.ts
@@ -1,0 +1,93 @@
+/**
+ * 登録セッションデータを管理するユーティリティ
+ * httpOnly Cookieを使用してサーバーサイドでデータを保存
+ */
+
+import type { RegisterSessionKey, RegisterSessionData } from '@/types/register-session'
+
+/**
+ * セッションデータを取得
+ */
+export async function getRegisterSession(): Promise<RegisterSessionData | null> {
+  try {
+    const response = await fetch('/api/auth/register/session', {
+      method: 'GET',
+      credentials: 'include',
+    })
+    
+    if (!response.ok) {
+      return null
+    }
+    
+    const result = await response.json()
+    return result.data
+  } catch {
+    console.error('Failed to get register session')
+    return null
+  }
+}
+
+/**
+ * セッションデータの特定のキーを取得
+ */
+export async function getRegisterSessionItem<T = unknown>(key: RegisterSessionKey): Promise<T | null> {
+  const data = await getRegisterSession()
+  if (!data) return null
+  return (data[key] as T) ?? null
+}
+
+/**
+ * セッションデータを保存
+ */
+export async function setRegisterSessionItem(key: RegisterSessionKey, value: unknown): Promise<boolean> {
+  try {
+    const response = await fetch('/api/auth/register/session', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      credentials: 'include',
+      body: JSON.stringify({ key, value }),
+    })
+    
+    return response.ok
+  } catch {
+    console.error('Failed to set register session item')
+    return false
+  }
+}
+
+/**
+ * セッションデータの特定のキーを削除
+ */
+export async function removeRegisterSessionItem(key: RegisterSessionKey): Promise<boolean> {
+  try {
+    const response = await fetch(`/api/auth/register/session?key=${encodeURIComponent(key)}`, {
+      method: 'DELETE',
+      credentials: 'include',
+    })
+    
+    return response.ok
+  } catch {
+    console.error('Failed to remove register session item')
+    return false
+  }
+}
+
+/**
+ * セッションデータを全て削除
+ */
+export async function clearRegisterSession(): Promise<boolean> {
+  try {
+    const response = await fetch('/api/auth/register/session', {
+      method: 'DELETE',
+      credentials: 'include',
+    })
+    
+    return response.ok
+  } catch {
+    console.error('Failed to clear register session')
+    return false
+  }
+}
+

--- a/frontend/src/types/register-session.ts
+++ b/frontend/src/types/register-session.ts
@@ -1,0 +1,20 @@
+/**
+ * 登録セッションデータの型定義
+ * httpOnly Cookieを使用してサーバーサイドでデータを保存する際の型
+ */
+
+export type RegisterSessionKey = 
+  | 'registerEmail' 
+  | 'registerFormData' 
+  | 'referrerUserId' 
+  | 'userEmail' 
+  | 'editFormData'
+
+export interface RegisterSessionData {
+  registerEmail?: string
+  registerFormData?: Record<string, unknown>
+  referrerUserId?: string
+  userEmail?: string
+  editFormData?: Record<string, unknown>
+}
+


### PR DESCRIPTION
## 概要
ユーザ本登録用の一時URLにメールアドレスがクエリパラメータとして含まれており、HTMLソースから閲覧可能な状態になっていた脆弱性を修正しました。

## 変更内容
- URLパラメータからemailを削除
- 新規登録画面からメールアドレス表示を削除（HTMLソースに含まれないようにするため）
- メールアドレスはAPIから取得してバリデーションに使用するが、画面には表示しない
- トークンはUUID形式で、メールアドレスなどの個人情報を含まない

## 対応した脆弱性
- ユーザ本登録用の一時URL内ページでログインIDである「メールアドレス」がHTMLソースから閲覧可能だった問題を解消

## 確認事項
- [x] リンターチェック完了（エラー0件）
- [x] ビルドチェック完了（エラーなし）