### PR TITLE
fix: さいたまアプリ連携のポイント付与失敗時に新規登録画面に戻り、エラーを表示

### DIFF
--- a/frontend/src/app/register-confirmation/page.tsx
+++ b/frontend/src/app/register-confirmation/page.tsx
@@ -194,12 +194,6 @@ export default function RegisterConfirmationPage() {
         // 登録成功後はサーバーサイドセッションをクリア
         await clearRegisterSession()
 
-        // さいたま市アプリ連携が失敗した場合（ポイント付与API失敗）
-        if (result.saitamaAppLinkFailed) {
-          setShowSaitamaFailedModal(true)
-          return
-        }
-
         // さいたま市アプリ連携でポイント付与があった場合はモーダルを表示
         if (result.pointsGranted) {
           setPointsGranted(result.pointsGranted)
@@ -216,12 +210,27 @@ export default function RegisterConfirmationPage() {
         }
       } else {
         // エラーハンドリング
+        const errorCode = result.error?.code || result.errorCode
         const errorMessage = result.message || result.error?.message || '登録に失敗しました'
 
         // 409エラー（既存アカウント）の場合は特別な処理
-        if (response.status === 409 && result.errorCode === 'USER_ALREADY_EXISTS') {
-          // ログイン画面にリダイレクト
-          router.push(`/?error=already_registered`)
+        if (response.status === 409 && (errorCode === 'USER_ALREADY_EXISTS' || errorCode === 'SAITAMA_APP_ID_ALREADY_EXISTS')) {
+          if (errorCode === 'USER_ALREADY_EXISTS') {
+            // ログイン画面にリダイレクト
+            router.push(`/?error=already_registered`)
+          } else {
+            // さいたま市アプリID重複の場合は新規登録画面に戻す
+            const tokenParam = token ? `?token=${encodeURIComponent(token)}` : ''
+            const shopIdParam = shopId ? `&shop_id=${encodeURIComponent(shopId)}` : ''
+            const errorParam = `&error=${encodeURIComponent(errorMessage)}`
+            router.push(`/register${tokenParam}${shopIdParam}${errorParam}`)
+          }
+        } else if (response.status === 500 && errorCode === 'POINT_GRANT_FAILED') {
+          // ポイント付与失敗の場合は新規登録画面に戻す
+          const tokenParam = token ? `?token=${encodeURIComponent(token)}` : ''
+          const shopIdParam = shopId ? `&shop_id=${encodeURIComponent(shopId)}` : ''
+          const errorParam = `&error=${encodeURIComponent(errorMessage)}`
+          router.push(`/register${tokenParam}${shopIdParam}${errorParam}`)
         } else {
           alert(errorMessage)
         }

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -33,6 +33,12 @@ export default function RegisterPage() {
       const shop_id = urlParams.get('shop_id') || undefined
       const ref = urlParams.get('ref') // 紹介者IDを取得
       const isEdit = urlParams.get('edit') === 'true'
+      const errorParam = urlParams.get('error') // エラーメッセージを取得
+
+      // エラーパラメータがある場合は表示
+      if (errorParam) {
+        setError(decodeURIComponent(errorParam))
+      }
 
       // トークンが存在しない場合はメール登録画面にリダイレクト
       if (!tokenParam || tokenParam.trim() === '') {
@@ -139,8 +145,8 @@ export default function RegisterPage() {
     )
   }
 
-  // エラー表示
-  if (error) {
+  // トークン関連のエラー（トークンが無効など）の場合は専用画面を表示
+  if (error && (!token || !email)) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-green-50 to-green-100 flex items-center justify-center">
         <div className="text-center">
@@ -160,6 +166,7 @@ export default function RegisterPage() {
       onLogoClick={handleLogoClick}
       isLoading={isLoading}
       backgroundColorClass="bg-gradient-to-br from-green-50 to-green-100"
+      errorMessage={error || undefined}
     />
   )
 }

--- a/frontend/src/components/organisms/RegisterContainer.tsx
+++ b/frontend/src/components/organisms/RegisterContainer.tsx
@@ -12,6 +12,7 @@ interface RegisterContainerProps {
   onLogoClick: () => void
   isLoading?: boolean
   backgroundColorClass?: string
+  errorMessage?: string
 }
 
 export function RegisterContainer({
@@ -21,7 +22,8 @@ export function RegisterContainer({
   onCancel,
   onLogoClick,
   isLoading,
-  backgroundColorClass = "bg-gradient-to-br from-green-50 to-green-100"
+  backgroundColorClass = "bg-gradient-to-br from-green-50 to-green-100",
+  errorMessage
 }: RegisterContainerProps) {
   return (
     <div className={`min-h-screen ${backgroundColorClass} flex flex-col`}>
@@ -36,6 +38,12 @@ export function RegisterContainer({
               <h2 className="text-2xl font-bold text-gray-900 mb-2">新規登録</h2>
               <p className="text-gray-600">必要事項を入力してください</p>
             </div>
+
+            {errorMessage && (
+              <div className="mb-6 p-4 bg-red-50 border border-red-200 rounded-lg">
+                <p className="text-sm text-red-600">{errorMessage}</p>
+              </div>
+            )}
 
             <RegisterForm
               email={email}


### PR DESCRIPTION
## 概要
さいたま市みんなのアプリ連携のポイント付与が失敗した場合、新規登録画面に戻り、エラーメッセージを表示するように修正しました。

## 変更内容
- ポイント付与失敗時は新規登録画面にリダイレクト
- エラーメッセージをURLパラメータから取得して表示
- RegisterContainerにエラーメッセージ表示機能を追加

## 関連PR
- tamanomi-api: https://github.com/HV-development/tamanomi-api/pull/118

## テスト
- [x] ビルドチェック完了