### PR TITLE
fix: クーポンAPIのデフォルト値を申請中・非公開に修正

### DIFF
--- a/frontend/src/app/api/coupons/route.ts
+++ b/frontend/src/app/api/coupons/route.ts
@@ -12,22 +12,19 @@ export async function GET(request: NextRequest) {
     const shopId = searchParams.get('shopId')
     const page = searchParams.get('page') || '1'
     const limit = searchParams.get('limit') || '100'
-    const status = searchParams.get('status') || 'active'
-    const isPublic = searchParams.get('isPublic')
+    const status = searchParams.get('status') || 'pending'  // デフォルトを申請中に
+    const isPublic = searchParams.get('isPublic') || 'false'  // デフォルトを非公開に
 
     // クエリパラメータを構築
     const queryParams = new URLSearchParams({
       page,
       limit,
       status,
+      isPublic,
     })
     
     if (shopId) {
       queryParams.append('shopId', shopId)
-    }
-    
-    if (isPublic) {
-      queryParams.append('isPublic', isPublic)
     }
 
     const authHeader = getAuthHeader(request)


### PR DESCRIPTION
## 概要
クーポン一覧APIのデフォルト値を修正し、公開条件を明確化しました。

## 変更内容
- `status`のデフォルト値を`'active'`から`'pending'`（申請中）に変更
- `isPublic`のデフォルト値を`'false'`（非公開）に設定

## 公開条件
ユーザー画面にクーポンを表示するには、以下の両方の条件を満たす必要があります：
- 承認ステータスが「承認済み」（status = approved）
- 公開ステータスが「公開中」（isPublic = true）

## 影響範囲
- クライアント側（`useAppHandlers.ts`）は既に`status=approved&isPublic=true`を明示的に指定しているため、既存の動作に影響なし