### PR TITLE
feat: ティザーサイト（メンテナンスページ）にサービス開始日の告知を追加

### DIFF
--- a/frontend/src/app/maintenance/page.tsx
+++ b/frontend/src/app/maintenance/page.tsx
@@ -46,8 +46,11 @@ export default function MaintenancePage() {
           className="opacity-0 animate-fade-in"
           style={{ animationDelay: '0.8s' }}
         >
-          <h1 className="text-base md:text-3xl font-medium text-[#007D4F] mb-4 tracking-wide">
-            公開までしばらくお待ちください
+          <p className="text-sm md:text-base text-[#007D4F]/80 mb-2">
+            ユーザー新規登録・利用開始は
+          </p>
+          <h1 className="text-xl md:text-3xl font-bold text-[#007D4F] mb-4 tracking-wide">
+            令和7年1月20日（火）スタート！
           </h1>
           
           {/* 装飾的なライン */}


### PR DESCRIPTION
## Summary
- メンテナンスページ（ティザーサイト）に「ユーザー新規登録・利用開始は令和7年1月20日（火）スタート！」の告知を追加
- 「公開までしばらくお待ちください」のメッセージを開始日告知に置き換え

## Test plan
- [ ] ティザーサイト（/maintenance）で告知テキストが正しく表示されることを確認