### PR TITLE
feat: ジャンル選択からイベント出店を一時的に非表示

### DIFF
--- a/frontend/src/components/molecules/GenrePopup.tsx
+++ b/frontend/src/components/molecules/GenrePopup.tsx
@@ -30,7 +30,7 @@ const GENRES = [
   { value: "bar", label: "バー" },
   { value: "cafe", label: "カフェ" },
   { value: "shokudo", label: "食堂" },
-  { value: "event", label: "イベント出店" },
+  // { value: "event", label: "イベント出店" }, // 一時的に非表示
 ]
 
 export function GenrePopup({ isOpen, selectedGenres, onGenreToggle, onClose, onClear }: GenrePopupProps) {


### PR DESCRIPTION
## Summary
- ジャンル選択ポップアップから「イベント出店」の選択肢を一時的に非表示にしました
- GENRES配列内の該当項目をコメントアウトして対応

## 変更ファイル
- `frontend/src/components/molecules/GenrePopup.tsx`

## 復元方法
再度表示する場合は、コメントを解除するだけで元に戻せます。

## Test plan
- [ ] ジャンル選択ポップアップを開き、「イベント出店」が表示されていないことを確認
- [ ] 他のジャンル選択が正常に動作することを確認