### PR TITLE
Feature/mypage payment method change

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
-    "@hv-development/schemas": "1.115.0",
+    "@hv-development/schemas": "1.116.0",
     "@radix-ui/react-accordion": "1.2.2",
     "@radix-ui/react-alert-dialog": "1.1.4",
     "@radix-ui/react-aspect-ratio": "1.1.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -13,8 +13,8 @@ dependencies:
     specifier: ^3.10.0
     version: 3.10.0(react-hook-form@7.68.0)
   '@hv-development/schemas':
-    specifier: 1.115.0
-    version: 1.115.0
+    specifier: 1.116.0
+    version: 1.116.0
   '@radix-ui/react-accordion':
     specifier: 1.2.2
     version: 1.2.2(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1)
@@ -579,8 +579,8 @@ packages:
     deprecated: Use @eslint/object-schema instead
     dev: true
 
-  /@hv-development/schemas@1.115.0:
-    resolution: {integrity: sha512-x0qurHNwP7pQhlQkQvV/50R17L6lWc5sZ49lcubx0JhlB+I0CgImsbBUXEiHrfxld+DYcNg9MovyQEO/8jZLLQ==, tarball: https://npm.pkg.github.com/download/@hv-development/schemas/1.115.0/3908d267347b88f86f747e9064591ba6d11bb060}
+  /@hv-development/schemas@1.116.0:
+    resolution: {integrity: sha512-T5IB/0rhVMNFfmWrIOFUHhfky7w7hcgOeBQZU+icCN89PwapoIqrG0TOLbyRv8oIYmqOhBUT5Cd0ovHAxKUohQ==, tarball: https://npm.pkg.github.com/download/@hv-development/schemas/1.116.0/9afce6970e9d49d69822ef4ac55872e847380b13}
     engines: {node: 22.x}
     dependencies:
       zod: 3.25.76

--- a/frontend/src/components/molecules/PlanManagement.tsx
+++ b/frontend/src/components/molecules/PlanManagement.tsx
@@ -9,10 +9,12 @@ interface PlanManagementProps {
   plan: Plan
   onChangePlan: () => void
   onCancelSubscription: () => void
+  onChangePaymentMethod?: () => void
+  hasPaymentMethod?: boolean
   className?: string
 }
 
-export function PlanManagement({ plan, onChangePlan, className = "" }: PlanManagementProps) {
+export function PlanManagement({ plan, onChangePlan, onChangePaymentMethod, hasPaymentMethod: _hasPaymentMethod, className = "" }: PlanManagementProps) {
   const formatDate = (date: Date) => {
     return format(date, "yyyy年M月d日", { locale: ja })
   }
@@ -76,6 +78,14 @@ export function PlanManagement({ plan, onChangePlan, className = "" }: PlanManag
           >
             変更する
           </button>
+          {onChangePaymentMethod && (
+            <button
+              onClick={onChangePaymentMethod}
+              className="w-full mt-3 bg-white border-2 border-green-300 hover:bg-green-50 text-green-700 py-3 px-4 rounded-xl font-medium transition-colors"
+            >
+              支払方法の変更
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/components/organisms/MypageContainer.tsx
+++ b/frontend/src/components/organisms/MypageContainer.tsx
@@ -2,7 +2,7 @@
 
 import React, { useMemo } from "react"
 import Image from "next/image"
-import { SquarePen, Crown, RefreshCw, Mail, Lock, LogOut, History, CreditCard, Share2, Copy, Check, Store } from "lucide-react"
+import { SquarePen, Crown, RefreshCw, Mail, Lock, LogOut, History, CreditCard, Share2, Copy, Check, Store, Wallet } from "lucide-react"
 import { User } from "lucide-react"
 import { Logo } from "../atoms/Logo"
 import { getNextRankInfo, getMonthsToNextRank, RANK_INFO } from "@/utils/rank-calculator"
@@ -44,6 +44,7 @@ interface MyPageContainerProps {
   onViewPlan: () => void
   onViewUsageHistory: () => void
   onViewPaymentHistory: () => void
+  onChangePaymentMethod?: () => void
   onStoreIntroduction?: () => void
   hasStoreIntroduction?: boolean
   onCancelSubscription: () => void
@@ -339,6 +340,7 @@ const MenuButtons = React.memo(({
   onChangePassword,
   onViewUsageHistory,
   onViewPaymentHistory,
+  onChangePaymentMethod,
   onStoreIntroduction,
   onLogout,
   plan,
@@ -350,6 +352,7 @@ const MenuButtons = React.memo(({
   onChangePassword: () => void
   onViewUsageHistory: () => void
   onViewPaymentHistory: () => void
+  onChangePaymentMethod?: () => void
   onStoreIntroduction?: () => void
   onLogout: () => void
   plan?: Plan
@@ -372,6 +375,9 @@ const MenuButtons = React.memo(({
       )}
       {appConfig.myPageSettings.showPlanManagement && (
         <MenuButton onClick={onViewPlan} icon={RefreshCw} label={planMenuLabel} />
+      )}
+      {appConfig.myPageSettings.showPlanManagement && plan && onChangePaymentMethod && (
+        <MenuButton onClick={onChangePaymentMethod} icon={Wallet} label="支払方法の変更" />
       )}
       {appConfig.myPageSettings.showEmailChange && (
         <MenuButton onClick={onChangeEmail} icon={Mail} label="メールアドレスの変更" />
@@ -404,6 +410,7 @@ export const MyPageContainer = React.memo(function MyPageContainer({
   onViewPlan,
   onViewUsageHistory,
   onViewPaymentHistory,
+  onChangePaymentMethod,
   onStoreIntroduction,
   hasStoreIntroduction,
   onWithdraw,
@@ -510,6 +517,7 @@ export const MyPageContainer = React.memo(function MyPageContainer({
               onChangePassword={onChangePassword}
               onViewUsageHistory={onViewUsageHistory}
               onViewPaymentHistory={onViewPaymentHistory}
+              onChangePaymentMethod={onChangePaymentMethod}
               onStoreIntroduction={onStoreIntroduction}
               onLogout={onLogout}
               plan={_plan}

--- a/frontend/src/components/organisms/PaymentMethodChangeContainer.tsx
+++ b/frontend/src/components/organisms/PaymentMethodChangeContainer.tsx
@@ -9,6 +9,7 @@ interface PaymentMethodChangeContainerProps {
   paymentCard: {
     paygentCustomerId: string
     paygentCustomerCardId: string
+    cardLastFour?: string | null
   } | null
   fromPlanChange: boolean
   onChangePaymentMethod: () => void
@@ -54,6 +55,15 @@ export function PaymentMethodChangeContainer({
 
         {/* 情報表示 */}
         <div className="space-y-4 mb-6">
+          {paymentCard && (
+            <div className="bg-gray-50 border border-gray-200 rounded-lg p-4">
+              <h3 className="text-sm font-bold text-gray-900 mb-2">現在の支払い方法</h3>
+              <p className="text-sm text-gray-700">
+                クレジットカード ************{paymentCard.cardLastFour ?? '----'}
+              </p>
+            </div>
+          )}
+
           <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
             <h3 className="text-sm font-bold text-blue-900 mb-2">変更について</h3>
             <ul className="text-sm text-blue-800 space-y-1">
@@ -63,14 +73,6 @@ export function PaymentMethodChangeContainer({
               <li>• 変更後、次回から新しいカードで決済されます</li>
             </ul>
           </div>
-
-          {paymentCard && (
-            <div className="bg-gray-50 border border-gray-200 rounded-lg p-4">
-              <p className="text-sm text-gray-700">
-                <span className="font-medium">現在の登録状態:</span> カード登録済み
-              </p>
-            </div>
-          )}
         </div>
 
         {/* ボタン */}

--- a/frontend/src/components/templates/HomeLayout.tsx
+++ b/frontend/src/components/templates/HomeLayout.tsx
@@ -376,6 +376,7 @@ export function HomeLayout({ onMount }: HomeLayoutProps) {
   const onPlanChangeSubmit = handlers.handlePlanChangeSubmit
   const onViewUsageHistory = handlers.handleViewUsageHistory
   const onViewPaymentHistory = handlers.handleViewPaymentHistory
+  const onChangePaymentMethod = (handlers as typeof handlers & { handleChangePaymentMethod: () => void }).handleChangePaymentMethod
   const onCancelSubscription = handlers.handleCancelSubscription
   const onWithdraw = handlers.handleWithdraw
   const onWithdrawConfirm = handlers.handleWithdrawConfirm
@@ -819,10 +820,7 @@ export function HomeLayout({ onMount }: HomeLayoutProps) {
           plan={plan}
           onChangePlan={() => onMyPageViewChange("plan-change")}
           onCancelSubscription={onCancelSubscription}
-          onChangePaymentMethod={() => {
-            // 支払い方法変更の専用画面に遷移
-            window.location.href = '/payment-method-change'
-          }}
+          onChangePaymentMethod={onChangePaymentMethod}
           hasPaymentMethod={hasPaymentMethod}
           onBack={() => onMyPageViewChange("main")}
           onLogoClick={onLogoClick}
@@ -858,6 +856,7 @@ export function HomeLayout({ onMount }: HomeLayoutProps) {
         onViewPlan={onViewPlan}
         onViewUsageHistory={onViewUsageHistory}
         onViewPaymentHistory={onViewPaymentHistory}
+        onChangePaymentMethod={onChangePaymentMethod}
         onStoreIntroduction={onStoreIntroduction}
         hasStoreIntroduction={hasStoreIntroduction}
         onCancelSubscription={onCancelSubscription}

--- a/frontend/src/components/templates/MypageLayout.tsx
+++ b/frontend/src/components/templates/MypageLayout.tsx
@@ -24,6 +24,7 @@ interface MyPageLayoutProps {
   onViewPlan: () => void
   onViewUsageHistory: () => void
   onViewPaymentHistory: () => void
+  onChangePaymentMethod?: () => void
   onStoreIntroduction?: () => void
   hasStoreIntroduction?: boolean
   onCancelSubscription: () => void
@@ -62,6 +63,7 @@ export function MyPageLayout({
   onViewPlan,
   onViewUsageHistory,
   onViewPaymentHistory,
+  onChangePaymentMethod,
   onStoreIntroduction,
   onCancelSubscription,
   onLogout,
@@ -100,6 +102,7 @@ export function MyPageLayout({
       onViewPlan={onViewPlan}
       onViewUsageHistory={onViewUsageHistory}
       onViewPaymentHistory={onViewPaymentHistory}
+      onChangePaymentMethod={onChangePaymentMethod}
       onStoreIntroduction={onStoreIntroduction}
       hasStoreIntroduction={hasStoreIntroduction}
       onCancelSubscription={onCancelSubscription}

--- a/frontend/src/hooks/useAppHandlers.ts
+++ b/frontend/src/hooks/useAppHandlers.ts
@@ -804,6 +804,10 @@ export const useAppHandlers = (
         navigation.navigateToMyPage("payment-history")
     }, [auth, navigation])
 
+    const handleChangePaymentMethod = useCallback(() => {
+        window.location.href = '/payment-method-change'
+    }, [])
+
     const handleCancelSubscription = useCallback(() => {
         // サブスクリプションキャンセル処理
     }, [])
@@ -1398,6 +1402,7 @@ export const useAppHandlers = (
         handlePlanChangeBack,
         handleViewUsageHistory,
         handleViewPaymentHistory,
+        handleChangePaymentMethod,
         handleCancelSubscription,
         handleWithdraw,
         handleWithdrawConfirm,

--- a/frontend/src/hooks/usePaymentMethodChange.ts
+++ b/frontend/src/hooks/usePaymentMethodChange.ts
@@ -9,6 +9,7 @@ export const usePaymentMethodChange = () => {
   const [paymentCard, setPaymentCard] = useState<{
     paygentCustomerId: string
     paygentCustomerCardId: string
+    cardLastFour?: string | null
   } | null>(null)
   const [useMockPayment, setUseMockPayment] = useState(false)
   const router = useRouter()
@@ -60,36 +61,89 @@ export const usePaymentMethodChange = () => {
       setIsLoading(true)
       setError('')
 
-      // モックモードの判定
-      const isMockMode = useMockPayment || !paymentCard
+      // モックモードの判定（API の設定のみ。API が false のときはカードがなくても実 Paygent 扱い）
+      const isMockMode = useMockPayment
 
       // モックモードの場合
       if (isMockMode) {
         const mockCustomerId = paymentCard?.paygentCustomerId || `cust_${Date.now()}`
         const mockCustomerCardId = paymentCard?.paygentCustomerCardId || 'mock_initial'
 
-        const response = await fetch('/api/payment/update', {
+        // ユーザー情報取得（プラン金額・runningId の有無で分岐するため）
+        const meResponse = await fetch('/api/user/me', {
+          cache: 'no-store',
+          credentials: 'include',
+        })
+        if (!meResponse.ok) {
+          throw new Error('ユーザー情報の取得に失敗しました')
+        }
+        const userData = await meResponse.json()
+        const plan = userData.plan
+        const userPlan = userData.userPlan
+        const currentAmount = plan != null
+          ? (plan.discountPrice != null && plan.discountPrice < plan.price ? plan.discountPrice : plan.price)
+          : undefined
+        const runningId = userPlan?.paygentRunningId || plan?.paygentRunningId || undefined
+
+        // 継続課金あり（runningId あり）→ 電文281でカード変更
+        if (runningId != null && runningId !== '') {
+          if (currentAmount == null || currentAmount === undefined) {
+            throw new Error('現在のプラン情報を取得できません。プランに加入後に支払方法の変更を行ってください。')
+          }
+          const response = await fetch('/api/payment/update', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              customerId: mockCustomerId,
+              customerCardId: mockCustomerCardId,
+              runningId,
+              amount: Number(currentAmount),
+              description: '支払方法変更（モック）',
+            })
+          })
+          if (!response.ok) {
+            const errorData = await response.json().catch(() => ({}))
+            throw new Error(errorData.error || 'PaymentSession作成に失敗しました')
+          }
+          await response.json()
+          const mockUrl = `/payment-mock?customer_id=${mockCustomerId}&operation_type=02`
+          window.location.href = mockUrl
+          return
+        }
+
+        // 無料期間・カード登録のみ（runningId なし）→ register でセッション作成しリダイレクト
+        const registerResponse = await fetch('/api/payment/register', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
           },
           body: JSON.stringify({
             customerId: mockCustomerId,
-            customerCardId: mockCustomerCardId,
-            // userEmailはバックエンドで認証トークンから取得するため、送信しない
           })
         })
-
-        if (!response.ok) {
-          const errorData = await response.json().catch(() => ({}))
-          throw new Error(errorData.error || 'PaymentSession作成に失敗しました')
+        if (!registerResponse.ok) {
+          const errorData = await registerResponse.json().catch(() => ({}))
+          throw new Error(errorData.error || errorData.message || 'カード変更の準備に失敗しました')
         }
-
-        await response.json()
-
-        // モック画面にリダイレクト
-        const mockUrl = `/payment-mock?customer_id=${mockCustomerId}&operation_type=02`
-        window.location.href = mockUrl
+        const data = await registerResponse.json()
+        if (data.redirectUrl && data.params) {
+          const form = document.createElement('form')
+          form.method = 'POST'
+          form.action = data.redirectUrl
+          Object.keys(data.params).forEach((key: string) => {
+            const input = document.createElement('input')
+            input.type = 'hidden'
+            input.name = key
+            input.value = data.params[key]
+            form.appendChild(input)
+          })
+          document.body.appendChild(form)
+          form.submit()
+        } else {
+          window.location.href = `/payment-mock?customer_id=${mockCustomerId}&operation_type=02`
+        }
         return
       }
 


### PR DESCRIPTION

支払方法変更時の amount・runningId を /api/user/me から取得して /api/payment/update に送る。
無料期間・カード登録のみ（runningId なし）のときは /api/payment/update は使わず、/api/payment/register でセッション作成してリダイレクト。
モック判定を API の useMockPayment のみに変更（カード未登録でも実 Paygent 扱いにする）。
frontend/src/components/organisms/PaymentMethodChangeContainer.tsx
支払方法変更画面の表示まわり（上記フローに合わせた調整）。
直近コミット: feat: マイページメニューに支払方法の変更を追加