### PR TITLE
プラン登録/プラン変更/支払方法変更処理の見直し

### DIFF
--- a/frontend/src/components/molecules/PlanChangeForm.tsx
+++ b/frontend/src/components/molecules/PlanChangeForm.tsx
@@ -612,7 +612,7 @@ export function PlanChangeForm({ currentPlan, onPlanChange, onCancel, isLoading 
                 支払い方法も変更する
               </div>
               <p className="text-xs text-purple-700">
-                プラン変更後、自動的にカード情報の変更画面に移動します
+                プラン変更完了後、続けてカード情報の変更画面に移動します
               </p>
             </div>
           </label>

--- a/frontend/src/components/organisms/PlanChangeForm.tsx
+++ b/frontend/src/components/organisms/PlanChangeForm.tsx
@@ -612,7 +612,7 @@ export function PlanChangeForm({ currentPlan, onPlanChange, onCancel, isLoading 
                 支払い方法も変更する
               </div>
               <p className="text-xs text-purple-700">
-                プラン変更後、自動的にカード情報の変更画面に移動します
+                プラン変更完了後、続けてカード情報の変更画面に移動します
               </p>
             </div>
           </label>


### PR DESCRIPTION
**背景**
API 側で alsoChangePaymentMethod 時も先にプラン変更（電文281等）を完結させる 挙動に合わせ、画面上の説明が「プラン変更直後に自動で遷移」と読めると実態とずれるため、プラン変更が完了してからカード変更画面へ進む旨を明示する。

**変更内容**
「支払い方法も変更する」 の補足文言を更新（molecules/PlanChangeForm.tsx / organisms/PlanChangeForm.tsx で同一）。
変更前: プラン変更後、自動的にカード情報の変更画面に移動します
変更後: プラン変更完了後、続けてカード情報の変更画面に移動します