### PR TITLE
トークンCookie処理の一元化とログイン時のCookie未設定バグ修正

### DIFF
--- a/frontend/src/app/api/auth/email/change/route.ts
+++ b/frontend/src/app/api/auth/email/change/route.ts
@@ -1,8 +1,6 @@
 import { NextRequest } from 'next/server'
 import { buildApiUrl } from '@/lib/api-config'
-import { getRefreshToken } from '@/lib/auth-header'
-import { COOKIE_MAX_AGE, COOKIE_NAMES } from '@/lib/cookie-config'
-import { secureFetchWithCommonHeaders } from '@/lib/fetch-utils'
+import { authenticatedFetch } from '@/lib/auth-fetch'
 import { createNoCacheResponse } from '@/lib/response-utils'
 
 export const dynamic = 'force-dynamic'
@@ -11,7 +9,6 @@ export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
 
-    // バリデーション
     if (!body.currentPassword || !body.newEmail || !body.confirmEmail) {
       return createNoCacheResponse(
         { error: { message: '現在のパスワード、新しいメールアドレス、確認メールアドレスは必須です' } },
@@ -19,7 +16,6 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    // メールアドレスの一致確認
     if (body.newEmail !== body.confirmEmail) {
       return createNoCacheResponse(
         { error: { message: '新しいメールアドレスと確認メールアドレスが一致しません' } },
@@ -27,18 +23,14 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    // バックエンドAPIに転送
     const fullUrl = buildApiUrl('/email/change')
 
     const controller = new AbortController()
     const timeoutId = setTimeout(() => controller.abort(), 10000)
 
     try {
-      const response = await secureFetchWithCommonHeaders(request, fullUrl, {
+      const { response } = await authenticatedFetch(request, fullUrl, {
         method: 'POST',
-        headerOptions: {
-          requireAuth: true,
-        },
         body: JSON.stringify({
           currentPassword: body.currentPassword,
           newEmail: body.newEmail,
@@ -48,121 +40,7 @@ export async function POST(request: NextRequest) {
       })
 
       clearTimeout(timeoutId)
-
-      // 認証エラーの場合、リフレッシュトークンで再試行
-      if (response.status === 401) {
-        const refreshToken = getRefreshToken(request)
-        
-        if (refreshToken) {
-          // リフレッシュトークンでトークン更新
-          const refreshUrl = buildApiUrl('/refresh')
-          const refreshResponse = await secureFetchWithCommonHeaders(request, refreshUrl, {
-            method: 'POST',
-            headerOptions: {
-              requireAuth: false,
-            },
-            body: JSON.stringify({ refreshToken }),
-          })
-          
-          if (refreshResponse.ok) {
-            const refreshData = await refreshResponse.json()
-            
-            // 新しいトークンで元のリクエストを再試行
-            const newAuthHeader = `Bearer ${refreshData.accessToken}`
-            const retryResponse = await secureFetchWithCommonHeaders(request, fullUrl, {
-              method: 'POST',
-              headerOptions: {
-                requireAuth: true,
-                customHeaders: {
-                  'Authorization': newAuthHeader,
-                },
-              },
-              body: JSON.stringify({
-                currentPassword: body.currentPassword,
-                newEmail: body.newEmail,
-                confirmEmail: body.confirmEmail,
-              }),
-            })
-            
-            const retryData = await retryResponse.json()
-            
-            if (retryResponse.ok) {
-              // リフレッシュされたトークンをCookieに反映
-              const res = createNoCacheResponse(retryData)
-              const isSecure = (() => {
-                try { return new URL(request.url).protocol === 'https:'; } catch { return process.env.NODE_ENV === 'production'; }
-              })()
-              
-              // 新しいトークンをCookieに設定
-              if (refreshData.accessToken) {
-                res.cookies.set('accessToken', '', { httpOnly: true, secure: isSecure, sameSite: 'strict', path: '/', maxAge: 0 })
-                res.cookies.set('__Host-accessToken', '', { httpOnly: true, secure: isSecure, sameSite: 'strict', path: '/', maxAge: 0 })
-                res.cookies.set(COOKIE_NAMES.ACCESS_TOKEN, refreshData.accessToken, {
-                  httpOnly: true,
-                  secure: isSecure,
-                  sameSite: 'strict',
-                  path: '/',
-                  maxAge: COOKIE_MAX_AGE.ACCESS_TOKEN,
-                })
-                if (isSecure) {
-                  res.cookies.set(COOKIE_NAMES.HOST_ACCESS_TOKEN, refreshData.accessToken, {
-                    httpOnly: true,
-                    secure: true,
-                    sameSite: 'strict',
-                    path: '/',
-                    maxAge: COOKIE_MAX_AGE.ACCESS_TOKEN,
-                  })
-                }
-              }
-              if (refreshData.refreshToken) {
-                res.cookies.set('refreshToken', '', { httpOnly: true, secure: isSecure, sameSite: 'strict', path: '/', maxAge: 0 })
-                res.cookies.set('__Host-refreshToken', '', { httpOnly: true, secure: isSecure, sameSite: 'strict', path: '/', maxAge: 0 })
-                res.cookies.set(COOKIE_NAMES.REFRESH_TOKEN, refreshData.refreshToken, {
-                  httpOnly: true,
-                  secure: isSecure,
-                  sameSite: 'strict',
-                  path: '/',
-                  maxAge: COOKIE_MAX_AGE.REFRESH_TOKEN,
-                })
-                if (isSecure) {
-                  res.cookies.set(COOKIE_NAMES.HOST_REFRESH_TOKEN, refreshData.refreshToken, {
-                    httpOnly: true,
-                    secure: true,
-                    sameSite: 'strict',
-                    path: '/',
-                    maxAge: COOKIE_MAX_AGE.REFRESH_TOKEN,
-                  })
-                }
-              }
-              
-              return res
-            }
-            
-            // リトライが失敗
-            return createNoCacheResponse(
-              { error: retryData.error || { message: 'メールアドレス変更に失敗しました' } },
-              { status: retryResponse.status }
-            )
-          }
-        }
-        
-        // リフレッシュに失敗した場合
-        return createNoCacheResponse(
-          { error: { message: '認証トークンが無効です。再度ログインしてください。' } },
-          { status: 401 }
-        )
-      }
-
-      const responseData = await response.json()
-
-      if (!response.ok) {
-        return createNoCacheResponse(
-          { error: responseData.error || { message: 'メールアドレス変更に失敗しました' } },
-          { status: response.status }
-        )
-      }
-
-      return createNoCacheResponse(responseData)
+      return response
     } catch (fetchError) {
       clearTimeout(timeoutId)
 

--- a/frontend/src/app/api/auth/login/route.ts
+++ b/frontend/src/app/api/auth/login/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server'
 import { buildApiUrl } from '@/lib/api-config'
 import { secureFetchWithCommonHeaders } from '@/lib/fetch-utils'
 import { createNoCacheResponse } from '@/lib/response-utils'
+import { setTokenCookies, isSecureRequest } from '@/lib/token-cookie'
 
 export const dynamic = 'force-dynamic'
 
@@ -14,7 +15,7 @@ export async function POST(request: NextRequest) {
     const response = await secureFetchWithCommonHeaders(request, fullUrl, {
       method: 'POST',
       headerOptions: {
-        requireAuth: false, // ログインエンドポイントは認証不要
+        requireAuth: false,
       },
       body: JSON.stringify({
         email,
@@ -25,31 +26,12 @@ export async function POST(request: NextRequest) {
     if (!response.ok) {
       const errorData = await response.json().catch(() => ({}))
 
-      // エラーメッセージを取得（formatErrorResponseの構造に対応）
       let errorMessage = errorData.error?.message || errorData.message || 'ログインに失敗しました'
 
-      // 退会済みアカウントの場合、より分かりやすいメッセージに変更
       if (errorMessage.includes('退会済み') || errorMessage.includes('suspended')) {
         errorMessage = 'このアカウントは退会済みです。同じメールアドレスで新規登録を行ってください。'
       }
 
-      // バリデーションエラーの場合
-      if (response.status === 400) {
-        return createNoCacheResponse(
-          { error: errorMessage },
-          { status: response.status }
-        )
-      }
-
-      // 認証エラー（401）の場合
-      if (response.status === 401) {
-        return createNoCacheResponse(
-          { error: errorMessage },
-          { status: response.status }
-        )
-      }
-
-      // その他のエラー
       return createNoCacheResponse(
         { error: errorMessage },
         { status: response.status }
@@ -58,10 +40,11 @@ export async function POST(request: NextRequest) {
 
     const data = await response.json()
 
-    // トークンをクッキーに保存するなどの処理が必要な場合はここで実行
-    // 現時点では単純にレスポンスを返す
+    const res = createNoCacheResponse({ message: 'Login successful' })
+    const isSecure = isSecureRequest(request)
+    setTokenCookies(res, data, isSecure)
 
-    return createNoCacheResponse(data)
+    return res
   } catch (error: unknown) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error'
     console.error('❌ [auth/login] Route error:', errorMessage, error)

--- a/frontend/src/app/api/auth/logout/route.ts
+++ b/frontend/src/app/api/auth/logout/route.ts
@@ -1,19 +1,18 @@
 import { NextRequest } from 'next/server'
 import { buildApiUrl } from '@/lib/api-config'
 import { secureFetchWithCommonHeaders } from '@/lib/fetch-utils'
-import { COOKIE_NAMES } from '@/lib/cookie-config'
 import { createNoCacheResponse } from '@/lib/response-utils'
+import { clearTokenCookies, isSecureRequest } from '@/lib/token-cookie'
 
 export const dynamic = 'force-dynamic'
 
 export async function POST(request: NextRequest) {
   try {
     const fullUrl = buildApiUrl('/logout')
-    // ログアウトは認証がオプショナル（認証されていない場合でもログアウト処理を実行）
     const response = await secureFetchWithCommonHeaders(request, fullUrl, {
       method: 'POST',
       headerOptions: {
-        requireAuth: false, // 認証がオプショナル
+        requireAuth: false,
       },
     })
 
@@ -21,89 +20,15 @@ export async function POST(request: NextRequest) {
     const nextResponse = createNoCacheResponse(
       ok ? { message: 'Logout successful' } : { message: 'Logout locally cleared', upstream: response.status }
     )
-    const isSecure = (() => {
-      try { return new URL(request.url).protocol === 'https:' } catch { return process.env.NODE_ENV === 'production' }
-    })()
-    
-    // accessToken クッキーを削除（プレフィックス付き）
-    nextResponse.cookies.set(COOKIE_NAMES.ACCESS_TOKEN, '', {
-      httpOnly: true,
-      secure: isSecure,
-      sameSite: 'strict',
-      maxAge: 0,
-      path: '/',
-    })
-    nextResponse.cookies.set(COOKIE_NAMES.HOST_ACCESS_TOKEN, '', {
-      httpOnly: true,
-      secure: isSecure,
-      sameSite: 'strict',
-      maxAge: 0,
-      path: '/',
-    })
-    
-    // refreshToken クッキーを削除（プレフィックス付き）
-    nextResponse.cookies.set(COOKIE_NAMES.REFRESH_TOKEN, '', {
-      httpOnly: true,
-      secure: isSecure,
-      sameSite: 'strict',
-      maxAge: 0,
-      path: '/',
-    })
-    nextResponse.cookies.set(COOKIE_NAMES.HOST_REFRESH_TOKEN, '', {
-      httpOnly: true,
-      secure: isSecure,
-      sameSite: 'strict',
-      maxAge: 0,
-      path: '/',
-    })
+    const isSecure = isSecureRequest(request)
+    clearTokenCookies(nextResponse, isSecure)
 
-    // 旧Cookie（プレフィックス無し）も削除して衝突を解消
-    nextResponse.cookies.set('accessToken', '', { httpOnly: true, secure: isSecure, sameSite: 'strict', maxAge: 0, path: '/' })
-    nextResponse.cookies.set('__Host-accessToken', '', { httpOnly: true, secure: isSecure, sameSite: 'strict', maxAge: 0, path: '/' })
-    nextResponse.cookies.set('refreshToken', '', { httpOnly: true, secure: isSecure, sameSite: 'strict', maxAge: 0, path: '/' })
-    nextResponse.cookies.set('__Host-refreshToken', '', { httpOnly: true, secure: isSecure, sameSite: 'strict', maxAge: 0, path: '/' })
-    
     return nextResponse
   } catch (error: unknown) {
     console.error('❌ API Route: Logout error', error)
     const res = createNoCacheResponse({ message: 'Local logout executed' }, { status: 200 })
-    const isSecure = (() => {
-      try { return new URL(request.url).protocol === 'https:' } catch { return process.env.NODE_ENV === 'production' }
-    })()
-    
-    res.cookies.set(COOKIE_NAMES.ACCESS_TOKEN, '', {
-      httpOnly: true,
-      secure: isSecure,
-      sameSite: 'strict',
-      maxAge: 0,
-      path: '/',
-    })
-    res.cookies.set(COOKIE_NAMES.HOST_ACCESS_TOKEN, '', {
-      httpOnly: true,
-      secure: isSecure,
-      sameSite: 'strict',
-      maxAge: 0,
-      path: '/',
-    })
-    res.cookies.set(COOKIE_NAMES.REFRESH_TOKEN, '', {
-      httpOnly: true,
-      secure: isSecure,
-      sameSite: 'strict',
-      maxAge: 0,
-      path: '/',
-    })
-    res.cookies.set(COOKIE_NAMES.HOST_REFRESH_TOKEN, '', {
-      httpOnly: true,
-      secure: isSecure,
-      sameSite: 'strict',
-      maxAge: 0,
-      path: '/',
-    })
-    // 旧Cookie（プレフィックス無し）も削除して衝突を解消
-    res.cookies.set('accessToken', '', { httpOnly: true, secure: isSecure, sameSite: 'strict', maxAge: 0, path: '/' })
-    res.cookies.set('__Host-accessToken', '', { httpOnly: true, secure: isSecure, sameSite: 'strict', maxAge: 0, path: '/' })
-    res.cookies.set('refreshToken', '', { httpOnly: true, secure: isSecure, sameSite: 'strict', maxAge: 0, path: '/' })
-    res.cookies.set('__Host-refreshToken', '', { httpOnly: true, secure: isSecure, sameSite: 'strict', maxAge: 0, path: '/' })
+    const isSecure = isSecureRequest(request)
+    clearTokenCookies(res, isSecure)
     return res
   }
 }

--- a/frontend/src/app/api/auth/password/change/route.ts
+++ b/frontend/src/app/api/auth/password/change/route.ts
@@ -1,8 +1,6 @@
 import { NextRequest } from 'next/server'
 import { buildApiUrl } from '@/lib/api-config'
-import { getRefreshToken } from '@/lib/auth-header'
-import { COOKIE_MAX_AGE, COOKIE_NAMES } from '@/lib/cookie-config'
-import { secureFetchWithCommonHeaders } from '@/lib/fetch-utils'
+import { authenticatedFetch } from '@/lib/auth-fetch'
 import { createNoCacheResponse } from '@/lib/response-utils'
 
 export const dynamic = 'force-dynamic'
@@ -10,7 +8,7 @@ export const dynamic = 'force-dynamic'
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
-    
+
     if (!body.currentPassword || !body.newPassword) {
       return createNoCacheResponse(
         { error: { message: '現在のパスワードと新しいパスワードは必須です' } },
@@ -20,132 +18,15 @@ export async function POST(request: NextRequest) {
 
     const fullUrl = buildApiUrl('/password/change')
 
-    const response = await secureFetchWithCommonHeaders(request, fullUrl, {
+    const { response } = await authenticatedFetch(request, fullUrl, {
       method: 'POST',
-      headerOptions: {
-        requireAuth: true,
-      },
       body: JSON.stringify({
         currentPassword: body.currentPassword,
         newPassword: body.newPassword,
       }),
     })
 
-    // 認証エラーの場合、リフレッシュトークンで再試行
-    if (response.status === 401) {
-      const refreshToken = getRefreshToken(request)
-      
-      if (refreshToken) {
-        // リフレッシュトークンでトークン更新
-        const refreshUrl = buildApiUrl('/refresh')
-        const refreshResponse = await secureFetchWithCommonHeaders(request, refreshUrl, {
-          method: 'POST',
-          headerOptions: {
-            requireAuth: false,
-          },
-          body: JSON.stringify({ refreshToken }),
-        })
-        
-        if (refreshResponse.ok) {
-          const refreshData = await refreshResponse.json()
-          
-          // 新しいトークンで元のリクエストを再試行
-          const newAuthHeader = `Bearer ${refreshData.accessToken}`
-          const retryResponse = await secureFetchWithCommonHeaders(request, fullUrl, {
-            method: 'POST',
-            headerOptions: {
-              requireAuth: true,
-              customHeaders: {
-                'Authorization': newAuthHeader,
-              },
-            },
-            body: JSON.stringify({
-              currentPassword: body.currentPassword,
-              newPassword: body.newPassword,
-            }),
-          })
-          
-          const retryData = await retryResponse.json()
-          
-          if (retryResponse.ok) {
-            // リフレッシュされたトークンをCookieに反映
-            const res = createNoCacheResponse(retryData)
-            const isSecure = (() => {
-              try { return new URL(request.url).protocol === 'https:'; } catch { return process.env.NODE_ENV === 'production'; }
-            })()
-            
-            // 新しいトークンをCookieに設定
-            if (refreshData.accessToken) {
-              res.cookies.set('accessToken', '', { httpOnly: true, secure: isSecure, sameSite: 'strict', path: '/', maxAge: 0 })
-              res.cookies.set('__Host-accessToken', '', { httpOnly: true, secure: isSecure, sameSite: 'strict', path: '/', maxAge: 0 })
-              res.cookies.set(COOKIE_NAMES.ACCESS_TOKEN, refreshData.accessToken, {
-                httpOnly: true,
-                secure: isSecure,
-                sameSite: 'strict',
-                path: '/',
-                maxAge: COOKIE_MAX_AGE.ACCESS_TOKEN,
-              })
-              if (isSecure) {
-                res.cookies.set(COOKIE_NAMES.HOST_ACCESS_TOKEN, refreshData.accessToken, {
-                  httpOnly: true,
-                  secure: true,
-                  sameSite: 'strict',
-                  path: '/',
-                  maxAge: COOKIE_MAX_AGE.ACCESS_TOKEN,
-                })
-              }
-            }
-            if (refreshData.refreshToken) {
-              res.cookies.set('refreshToken', '', { httpOnly: true, secure: isSecure, sameSite: 'strict', path: '/', maxAge: 0 })
-              res.cookies.set('__Host-refreshToken', '', { httpOnly: true, secure: isSecure, sameSite: 'strict', path: '/', maxAge: 0 })
-              res.cookies.set(COOKIE_NAMES.REFRESH_TOKEN, refreshData.refreshToken, {
-                httpOnly: true,
-                secure: isSecure,
-                sameSite: 'strict',
-                path: '/',
-                maxAge: COOKIE_MAX_AGE.REFRESH_TOKEN,
-              })
-              if (isSecure) {
-                res.cookies.set(COOKIE_NAMES.HOST_REFRESH_TOKEN, refreshData.refreshToken, {
-                  httpOnly: true,
-                  secure: true,
-                  sameSite: 'strict',
-                  path: '/',
-                  maxAge: COOKIE_MAX_AGE.REFRESH_TOKEN,
-                })
-              }
-            }
-            
-            return res
-          }
-          
-          // リトライが失敗
-          return createNoCacheResponse(
-            { error: retryData.error || { message: 'パスワード変更に失敗しました' } },
-            { status: retryResponse.status }
-          )
-        }
-      }
-      
-      // リフレッシュに失敗した場合
-      return createNoCacheResponse(
-        { error: { message: '認証トークンが無効です。再度ログインしてください。' } },
-        { status: 401 }
-      )
-    }
-
-    const data = await response.json()
-
-    if (!response.ok) {
-      console.error('❌ [password/change] Backend API error:', data)
-      return createNoCacheResponse(
-        { error: data.error || { message: 'パスワード変更に失敗しました' } },
-        { status: response.status }
-      )
-    }
-
-    return createNoCacheResponse(data)
-
+    return response
   } catch (error) {
     console.error('❌ [password/change] Route error:', error)
     return createNoCacheResponse(

--- a/frontend/src/app/api/auth/refresh/route.ts
+++ b/frontend/src/app/api/auth/refresh/route.ts
@@ -1,15 +1,14 @@
 import { NextRequest } from 'next/server'
 import { buildApiUrl } from '@/lib/api-config'
 import { getRefreshToken } from '@/lib/auth-header'
-import { COOKIE_MAX_AGE, COOKIE_NAMES } from '@/lib/cookie-config'
 import { secureFetchWithCommonHeaders } from '@/lib/fetch-utils'
 import { createNoCacheResponse } from '@/lib/response-utils'
+import { setTokenCookies, isSecureRequest } from '@/lib/token-cookie'
 
 export const dynamic = 'force-dynamic'
 
 export async function POST(request: NextRequest) {
   try {
-    // Cookieからリフレッシュトークンを取得
     const refreshToken = getRefreshToken(request)
 
     if (!refreshToken) {
@@ -24,7 +23,7 @@ export async function POST(request: NextRequest) {
     const response = await secureFetchWithCommonHeaders(request, fullUrl, {
       method: 'POST',
       headerOptions: {
-        requireAuth: false, // リフレッシュトークンは認証不要
+        requireAuth: false,
       },
       body: JSON.stringify({ refreshToken }),
     })
@@ -39,81 +38,12 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    // トークンをhttpOnly Cookieに保存し、ボディでは返却しない
     const res = createNoCacheResponse({ message: 'Token refresh successful' })
-    const isSecure = (() => {
-      try { return new URL(request.url).protocol === 'https:'; } catch { return process.env.NODE_ENV === 'production'; }
-    })()
-
     res.headers.set('Cache-Control', 'no-store')
     res.headers.set('Pragma', 'no-cache')
 
-    if (data.accessToken) {
-      const accessTokenMaxAge = COOKIE_MAX_AGE.ACCESS_TOKEN;
-      const accessTokenDays = accessTokenMaxAge / (60 * 60 * 24);
-      console.log('🍪 [auth/refresh] アクセストークンCookie設定:', {
-        maxAge: accessTokenMaxAge,
-        days: accessTokenDays,
-        hours: accessTokenMaxAge / (60 * 60),
-        configValue: COOKIE_MAX_AGE.ACCESS_TOKEN,
-      });
-      
-      // 旧Cookie（プレフィックス無し）を削除して衝突を解消
-      res.cookies.set('accessToken', '', { httpOnly: true, secure: isSecure, sameSite: 'strict', path: '/', maxAge: 0 })
-      res.cookies.set('__Host-accessToken', '', { httpOnly: true, secure: isSecure, sameSite: 'strict', path: '/', maxAge: 0 })
-
-      // 通常のCookie（開発環境・本番環境の両方で動作）
-      res.cookies.set(COOKIE_NAMES.ACCESS_TOKEN, data.accessToken, {
-        httpOnly: true,
-        secure: isSecure,
-        sameSite: 'strict',
-        path: '/',
-        maxAge: accessTokenMaxAge,
-      })
-      // __Host-プレフィックス付きCookie（HTTPS環境でのみ有効）
-      if (isSecure) {
-        res.cookies.set(COOKIE_NAMES.HOST_ACCESS_TOKEN, data.accessToken, {
-          httpOnly: true,
-          secure: true, // __Host-プレフィックスにはsecure: trueが必須
-          sameSite: 'strict',
-          path: '/',
-          maxAge: accessTokenMaxAge,
-        })
-      }
-    }
-    if (data.refreshToken) {
-      const refreshTokenMaxAge = COOKIE_MAX_AGE.REFRESH_TOKEN;
-      const refreshTokenDays = refreshTokenMaxAge / (60 * 60 * 24);
-      console.log('🍪 [auth/refresh] リフレッシュトークンCookie設定:', {
-        maxAge: refreshTokenMaxAge,
-        days: refreshTokenDays,
-        hours: refreshTokenMaxAge / (60 * 60),
-        configValue: COOKIE_MAX_AGE.REFRESH_TOKEN,
-      });
-      
-      // 旧Cookie（プレフィックス無し）を削除して衝突を解消
-      res.cookies.set('refreshToken', '', { httpOnly: true, secure: isSecure, sameSite: 'strict', path: '/', maxAge: 0 })
-      res.cookies.set('__Host-refreshToken', '', { httpOnly: true, secure: isSecure, sameSite: 'strict', path: '/', maxAge: 0 })
-
-      // 通常のCookie（開発環境・本番環境の両方で動作）
-      res.cookies.set(COOKIE_NAMES.REFRESH_TOKEN, data.refreshToken, {
-        httpOnly: true,
-        secure: isSecure,
-        sameSite: 'strict',
-        path: '/',
-        maxAge: refreshTokenMaxAge,
-      })
-      // __Host-プレフィックス付きCookie（HTTPS環境でのみ有効）
-      if (isSecure) {
-        res.cookies.set(COOKIE_NAMES.HOST_REFRESH_TOKEN, data.refreshToken, {
-          httpOnly: true,
-          secure: true, // __Host-プレフィックスにはsecure: trueが必須
-          sameSite: 'strict',
-          path: '/',
-          maxAge: refreshTokenMaxAge,
-        })
-      }
-    }
+    const isSecure = isSecureRequest(request)
+    setTokenCookies(res, data, isSecure)
 
     return res
   } catch (error) {

--- a/frontend/src/app/api/auth/register/route.ts
+++ b/frontend/src/app/api/auth/register/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest } from 'next/server'
 import { buildApiUrl } from '@/lib/api-config'
-import { COOKIE_MAX_AGE, COOKIE_NAMES } from '@/lib/cookie-config'
 import { secureFetchWithCommonHeaders } from '@/lib/fetch-utils'
 import { createNoCacheResponse } from '@/lib/response-utils'
+import { setTokenCookies, isSecureRequest } from '@/lib/token-cookie'
 
 export const dynamic = 'force-dynamic'
 
@@ -258,52 +258,9 @@ export async function POST(request: NextRequest) {
 
       const data = await response.json()
 
-      // トークンをCookieに保存（ログイン時と同様に）
       const nextResponse = createNoCacheResponse(data, { status: response.status })
-      const isSecure = (() => {
-        try { return new URL(request.url).protocol === 'https:' } catch { return process.env.NODE_ENV === 'production' }
-      })()
-
-      if (data.accessToken) {
-        // 旧Cookie（プレフィックス無し）を削除して衝突を解消
-        nextResponse.cookies.set('accessToken', '', { httpOnly: true, secure: isSecure, sameSite: 'strict', path: '/', maxAge: 0 })
-        nextResponse.cookies.set('__Host-accessToken', '', { httpOnly: true, secure: isSecure, sameSite: 'strict', path: '/', maxAge: 0 })
-
-        nextResponse.cookies.set(COOKIE_NAMES.ACCESS_TOKEN, data.accessToken, {
-          httpOnly: true,
-          secure: isSecure,
-          sameSite: 'strict',
-          path: '/',
-          maxAge: COOKIE_MAX_AGE.ACCESS_TOKEN, // 環境変数JWT_ACCESS_TOKEN_EXPIRES_INから取得（cookie-config.tsで一元管理）
-        })
-        nextResponse.cookies.set(COOKIE_NAMES.HOST_ACCESS_TOKEN, data.accessToken, {
-          httpOnly: true,
-          secure: isSecure,
-          sameSite: 'strict',
-          path: '/',
-          maxAge: COOKIE_MAX_AGE.ACCESS_TOKEN, // 環境変数JWT_ACCESS_TOKEN_EXPIRES_INから取得（cookie-config.tsで一元管理）
-        })
-      }
-      if (data.refreshToken) {
-        // 旧Cookie（プレフィックス無し）を削除して衝突を解消
-        nextResponse.cookies.set('refreshToken', '', { httpOnly: true, secure: isSecure, sameSite: 'strict', path: '/', maxAge: 0 })
-        nextResponse.cookies.set('__Host-refreshToken', '', { httpOnly: true, secure: isSecure, sameSite: 'strict', path: '/', maxAge: 0 })
-
-        nextResponse.cookies.set(COOKIE_NAMES.REFRESH_TOKEN, data.refreshToken, {
-          httpOnly: true,
-          secure: isSecure,
-          sameSite: 'strict',
-          path: '/',
-          maxAge: COOKIE_MAX_AGE.REFRESH_TOKEN, // 環境変数JWT_REFRESH_TOKEN_EXPIRES_INから取得（cookie-config.tsで一元管理）
-        })
-        nextResponse.cookies.set(COOKIE_NAMES.HOST_REFRESH_TOKEN, data.refreshToken, {
-          httpOnly: true,
-          secure: isSecure,
-          sameSite: 'strict',
-          path: '/',
-          maxAge: COOKIE_MAX_AGE.REFRESH_TOKEN, // 環境変数JWT_REFRESH_TOKEN_EXPIRES_INから取得（cookie-config.tsで一元管理）
-        })
-      }
+      const isSecure = isSecureRequest(request)
+      setTokenCookies(nextResponse, data, isSecure)
 
       return nextResponse
     } catch (fetchError) {

--- a/frontend/src/app/api/auth/verify-otp/route.ts
+++ b/frontend/src/app/api/auth/verify-otp/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest } from 'next/server'
 import { buildApiUrl } from '@/lib/api-config'
-import { COOKIE_MAX_AGE, COOKIE_NAMES } from '@/lib/cookie-config'
 import { secureFetchWithCommonHeaders } from '@/lib/fetch-utils'
 import { createNoCacheResponse } from '@/lib/response-utils'
+import { setTokenCookies, isSecureRequest } from '@/lib/token-cookie'
 
 export const dynamic = 'force-dynamic'
 
@@ -16,14 +16,13 @@ export async function POST(request: NextRequest) {
     const response = await secureFetchWithCommonHeaders(request, fullUrl, {
       method: 'POST',
       headerOptions: {
-        requireAuth: false, // OTP検証は認証不要
+        requireAuth: false,
       },
       body: JSON.stringify({ email, otp, requestId }),
     })
 
     if (!response.ok) {
       const errorData = await response.json().catch(() => ({}))
-      
 
       return createNoCacheResponse(
         { error: errorData.error?.message || errorData.message || 'OTP検証に失敗しました' },
@@ -33,61 +32,10 @@ export async function POST(request: NextRequest) {
 
     const data = await response.json()
 
-    // トークンをhttpOnly Cookieに保存し、ボディでは返却しない
     const res = createNoCacheResponse({ message: 'OTP verification successful' })
-    const isSecure = (() => {
-      try { return new URL(request.url).protocol === 'https:'; } catch { return process.env.NODE_ENV === 'production'; }
-    })()
-    
-    if (data.accessToken) {
-      // 旧Cookie（プレフィックス無し）を削除して衝突を解消
-      res.cookies.set('accessToken', '', { httpOnly: true, secure: isSecure, sameSite: 'strict', path: '/', maxAge: 0 })
-      res.cookies.set('__Host-accessToken', '', { httpOnly: true, secure: isSecure, sameSite: 'strict', path: '/', maxAge: 0 })
+    const isSecure = isSecureRequest(request)
+    setTokenCookies(res, data, isSecure)
 
-      // 通常のCookie（開発環境・本番環境の両方で動作）
-      res.cookies.set(COOKIE_NAMES.ACCESS_TOKEN, data.accessToken, {
-        httpOnly: true,
-        secure: isSecure,
-        sameSite: 'strict',
-        path: '/',
-        maxAge: COOKIE_MAX_AGE.ACCESS_TOKEN, // 環境変数JWT_ACCESS_TOKEN_EXPIRES_INから取得（cookie-config.tsで一元管理）
-      })
-      // __Host-プレフィックス付きCookie（HTTPS環境でのみ有効）
-      if (isSecure) {
-        res.cookies.set(COOKIE_NAMES.HOST_ACCESS_TOKEN, data.accessToken, {
-          httpOnly: true,
-          secure: true, // __Host-プレフィックスにはsecure: trueが必須
-          sameSite: 'strict',
-          path: '/',
-          maxAge: COOKIE_MAX_AGE.ACCESS_TOKEN, // 環境変数JWT_ACCESS_TOKEN_EXPIRES_INから取得（cookie-config.tsで一元管理）
-        })
-      }
-    }
-    if (data.refreshToken) {
-      // 旧Cookie（プレフィックス無し）を削除して衝突を解消
-      res.cookies.set('refreshToken', '', { httpOnly: true, secure: isSecure, sameSite: 'strict', path: '/', maxAge: 0 })
-      res.cookies.set('__Host-refreshToken', '', { httpOnly: true, secure: isSecure, sameSite: 'strict', path: '/', maxAge: 0 })
-
-      // 通常のCookie（開発環境・本番環境の両方で動作）
-      res.cookies.set(COOKIE_NAMES.REFRESH_TOKEN, data.refreshToken, {
-        httpOnly: true,
-        secure: isSecure,
-        sameSite: 'strict',
-        path: '/',
-        maxAge: COOKIE_MAX_AGE.REFRESH_TOKEN, // 環境変数JWT_REFRESH_TOKEN_EXPIRES_INから取得（cookie-config.tsで一元管理）
-      })
-      // __Host-プレフィックス付きCookie（HTTPS環境でのみ有効）
-      if (isSecure) {
-        res.cookies.set(COOKIE_NAMES.HOST_REFRESH_TOKEN, data.refreshToken, {
-          httpOnly: true,
-          secure: true, // __Host-プレフィックスにはsecure: trueが必須
-          sameSite: 'strict',
-          path: '/',
-          maxAge: COOKIE_MAX_AGE.REFRESH_TOKEN, // 環境変数JWT_REFRESH_TOKEN_EXPIRES_INから取得（cookie-config.tsで一元管理）
-        })
-      }
-    }
-    
     return res
   } catch {
     return createNoCacheResponse(

--- a/frontend/src/app/api/user/me/route.ts
+++ b/frontend/src/app/api/user/me/route.ts
@@ -1,8 +1,6 @@
 import { NextRequest } from 'next/server'
 import { buildApiUrl } from '@/lib/api-config'
-import { getRefreshToken } from '@/lib/auth-header'
-import { COOKIE_MAX_AGE, COOKIE_NAMES } from '@/lib/cookie-config'
-import { secureFetchWithCommonHeaders } from '@/lib/fetch-utils'
+import { authenticatedFetch } from '@/lib/auth-fetch'
 import { createNoCacheResponse } from '@/lib/response-utils'
 
 export const dynamic = 'force-dynamic'
@@ -11,153 +9,11 @@ export async function GET(request: NextRequest) {
   try {
     const fullUrl = buildApiUrl('/users/me')
 
-    const response = await secureFetchWithCommonHeaders(request, fullUrl, {
+    const { response } = await authenticatedFetch(request, fullUrl, {
       method: 'GET',
-      headerOptions: {
-        requireAuth: true, // 認証が必要
-      },
     })
 
-    // 401/403エラーの場合、リフレッシュトークンで再試行を試みる
-    if (response.status === 401 || response.status === 403) {
-      const refreshToken = getRefreshToken(request)
-      
-      if (refreshToken) {
-        // リフレッシュトークンでトークン更新（直接backend APIを呼び出す）
-        const refreshUrl = buildApiUrl('/refresh')
-        const refreshResponse = await secureFetchWithCommonHeaders(request, refreshUrl, {
-          method: 'POST',
-          headerOptions: {
-            requireAuth: false, // リフレッシュトークンは認証不要
-          },
-          body: JSON.stringify({ refreshToken }),
-        })
-        
-        if (refreshResponse.ok) {
-          const refreshData = await refreshResponse.json()
-          
-          // リフレッシュ成功、新しいトークンで元のリクエストを再試行
-          const newAuthHeader = `Bearer ${refreshData.accessToken}`
-          const retryResponse = await secureFetchWithCommonHeaders(request, fullUrl, {
-            method: 'GET',
-            headerOptions: {
-              requireAuth: true,
-              customHeaders: {
-                'Authorization': newAuthHeader,
-              },
-            },
-          })
-          
-          if (retryResponse.ok) {
-            const retryData = await retryResponse.json()
-            // リフレッシュされたトークンをCookieに反映
-            const res = createNoCacheResponse(retryData, { status: 200 })
-            const isSecure = (() => {
-              try { return new URL(request.url).protocol === 'https:'; } catch { return process.env.NODE_ENV === 'production'; }
-            })()
-            
-            // 新しいトークンをCookieに設定
-            if (refreshData.accessToken) {
-              // 旧Cookie（プレフィックス無し）を削除して衝突を解消
-              res.cookies.set('accessToken', '', { httpOnly: true, secure: isSecure, sameSite: 'strict', path: '/', maxAge: 0 })
-              res.cookies.set('__Host-accessToken', '', { httpOnly: true, secure: isSecure, sameSite: 'strict', path: '/', maxAge: 0 })
-
-              // 通常のCookie（開発環境・本番環境の両方で動作）
-              res.cookies.set(COOKIE_NAMES.ACCESS_TOKEN, refreshData.accessToken, {
-                httpOnly: true,
-                secure: isSecure,
-                sameSite: 'strict',
-                path: '/',
-                maxAge: COOKIE_MAX_AGE.ACCESS_TOKEN,
-              })
-              // __Host-プレフィックス付きCookie（HTTPS環境でのみ有効）
-              if (isSecure) {
-                res.cookies.set(COOKIE_NAMES.HOST_ACCESS_TOKEN, refreshData.accessToken, {
-                  httpOnly: true,
-                  secure: true,
-                  sameSite: 'strict',
-                  path: '/',
-                  maxAge: COOKIE_MAX_AGE.ACCESS_TOKEN,
-                })
-              }
-            }
-            if (refreshData.refreshToken) {
-              // 旧Cookie（プレフィックス無し）を削除して衝突を解消
-              res.cookies.set('refreshToken', '', { httpOnly: true, secure: isSecure, sameSite: 'strict', path: '/', maxAge: 0 })
-              res.cookies.set('__Host-refreshToken', '', { httpOnly: true, secure: isSecure, sameSite: 'strict', path: '/', maxAge: 0 })
-
-              // 通常のCookie（開発環境・本番環境の両方で動作）
-              res.cookies.set(COOKIE_NAMES.REFRESH_TOKEN, refreshData.refreshToken, {
-                httpOnly: true,
-                secure: isSecure,
-                sameSite: 'strict',
-                path: '/',
-                maxAge: COOKIE_MAX_AGE.REFRESH_TOKEN,
-              })
-              // __Host-プレフィックス付きCookie（HTTPS環境でのみ有効）
-              if (isSecure) {
-                res.cookies.set(COOKIE_NAMES.HOST_REFRESH_TOKEN, refreshData.refreshToken, {
-                  httpOnly: true,
-                  secure: true,
-                  sameSite: 'strict',
-                  path: '/',
-                  maxAge: COOKIE_MAX_AGE.REFRESH_TOKEN,
-                })
-              }
-            }
-            
-            return res
-          } else {
-            // リトライが失敗した場合、403エラーがアカウントタイプ不一致の可能性がある
-            const retryData = await retryResponse.json().catch(() => ({}))
-            if (retryResponse.status === 403 && retryData.message?.includes('アカウントタイプ')) {
-              return createNoCacheResponse(
-                { error: 'この機能はユーザーアカウント専用です' },
-                { status: 403 }
-              )
-            }
-          }
-        }
-      }
-      
-      // リフレッシュに失敗した場合
-      if (response.status === 403) {
-        // 403エラーがアカウントタイプ不一致の可能性があるかチェック
-        const data = await response.json().catch(() => ({}))
-        const errorMessage = data.message || data.error?.message || ''
-        if (errorMessage.includes('アカウントタイプ') || errorMessage.includes('account type')) {
-          return createNoCacheResponse(
-            { error: 'この機能はユーザーアカウント専用です' },
-            { status: 403 }
-          )
-        }
-      }
-      
-      // 認証エラーの場合は401を返す
-      return createNoCacheResponse(
-        { error: '認証が必要です' },
-        { status: 401 }
-      )
-    }
-
-    const data = await response.json()
-
-    if (!response.ok) {
-      console.error('❌ [user/me] Backend API error:', {
-        status: response.status,
-        statusText: response.statusText,
-        error: data,
-        url: fullUrl,
-      })
-      
-      return createNoCacheResponse(
-        { error: data.message || data.error?.message || 'ユーザー情報の取得に失敗しました' },
-        { status: response.status }
-      )
-    }
-    
-    return createNoCacheResponse(data)
-
+    return response
   } catch (error) {
     console.error('❌ [user/me] Route error:', error)
     return createNoCacheResponse(

--- a/frontend/src/app/api/user/payment-history/route.ts
+++ b/frontend/src/app/api/user/payment-history/route.ts
@@ -1,8 +1,6 @@
 import { NextRequest } from 'next/server'
 import { buildApiUrl } from '@/lib/api-config'
-import { getRefreshToken } from '@/lib/auth-header'
-import { COOKIE_MAX_AGE, COOKIE_NAMES } from '@/lib/cookie-config'
-import { secureFetchWithCommonHeaders } from '@/lib/fetch-utils'
+import { authenticatedFetch } from '@/lib/auth-fetch'
 import { createNoCacheResponse } from '@/lib/response-utils'
 
 export const dynamic = 'force-dynamic'
@@ -11,149 +9,11 @@ export async function GET(request: NextRequest) {
   try {
     const fullUrl = buildApiUrl('/users/me/payment-history')
 
-    const response = await secureFetchWithCommonHeaders(request, fullUrl, {
+    const { response } = await authenticatedFetch(request, fullUrl, {
       method: 'GET',
-      headerOptions: {
-        requireAuth: true, // 認証が必要
-      },
     })
 
-    // 認証エラーの場合は401を返す
-    if (response.status === 401) {
-      return createNoCacheResponse(
-        { error: '認証が必要です' },
-        { status: 401 }
-      )
-    }
-
-    const data = await response.json()
-
-    if (!response.ok) {
-      console.error('❌ [payment-history] Backend API error:', data)
-
-      // 401または403エラーの場合、リフレッシュトークンで再試行
-      if (response.status === 401 || response.status === 403) {
-        const refreshToken = getRefreshToken(request)
-
-        if (refreshToken) {
-          // リフレッシュトークンでトークン更新
-          const refreshUrl = buildApiUrl('/refresh')
-          const refreshResponse = await secureFetchWithCommonHeaders(request, refreshUrl, {
-            method: 'POST',
-            headerOptions: {
-              requireAuth: false, // リフレッシュトークンは認証不要
-            },
-            body: JSON.stringify({ refreshToken }),
-          })
-
-          if (refreshResponse.ok) {
-            const refreshData = await refreshResponse.json()
-
-            // リフレッシュ成功、新しいトークンで元のリクエストを再試行
-            const newAuthHeader = `Bearer ${refreshData.accessToken}`
-            const retryResponse = await secureFetchWithCommonHeaders(request, fullUrl, {
-              method: 'GET',
-              headerOptions: {
-                requireAuth: true,
-                customHeaders: {
-                  Authorization: newAuthHeader,
-                },
-              },
-            })
-
-            if (retryResponse.ok) {
-              const retryData = await retryResponse.json()
-              // リフレッシュされたトークンをCookieに反映
-              const res = createNoCacheResponse(retryData, { status: 200 })
-              const isSecure = (() => {
-                try {
-                  return new URL(request.url).protocol === 'https:'
-                } catch {
-                  return process.env.NODE_ENV === 'production'
-                }
-              })()
-
-              // 新しいトークンをCookieに設定
-              if (refreshData.accessToken) {
-                // 旧Cookie（プレフィックス無し）を削除して衝突を解消
-                res.cookies.set('accessToken', '', {
-                  httpOnly: true,
-                  secure: isSecure,
-                  sameSite: 'strict',
-                  path: '/',
-                  maxAge: 0,
-                })
-                res.cookies.set('__Host-accessToken', '', {
-                  httpOnly: true,
-                  secure: isSecure,
-                  sameSite: 'strict',
-                  path: '/',
-                  maxAge: 0,
-                })
-
-                res.cookies.set(COOKIE_NAMES.ACCESS_TOKEN, refreshData.accessToken, {
-                  httpOnly: true,
-                  secure: isSecure,
-                  sameSite: 'strict',
-                  path: '/',
-                  maxAge: COOKIE_MAX_AGE.ACCESS_TOKEN,
-                })
-                res.cookies.set(COOKIE_NAMES.HOST_ACCESS_TOKEN, refreshData.accessToken, {
-                  httpOnly: true,
-                  secure: isSecure,
-                  sameSite: 'strict',
-                  path: '/',
-                  maxAge: COOKIE_MAX_AGE.ACCESS_TOKEN,
-                })
-              }
-              if (refreshData.refreshToken) {
-                // 旧Cookie（プレフィックス無し）を削除して衝突を解消
-                res.cookies.set('refreshToken', '', {
-                  httpOnly: true,
-                  secure: isSecure,
-                  sameSite: 'strict',
-                  path: '/',
-                  maxAge: 0,
-                })
-                res.cookies.set('__Host-refreshToken', '', {
-                  httpOnly: true,
-                  secure: isSecure,
-                  sameSite: 'strict',
-                  path: '/',
-                  maxAge: 0,
-                })
-
-                res.cookies.set(COOKIE_NAMES.REFRESH_TOKEN, refreshData.refreshToken, {
-                  httpOnly: true,
-                  secure: isSecure,
-                  sameSite: 'strict',
-                  path: '/',
-                  maxAge: COOKIE_MAX_AGE.REFRESH_TOKEN,
-                })
-                res.cookies.set(COOKIE_NAMES.HOST_REFRESH_TOKEN, refreshData.refreshToken, {
-                  httpOnly: true,
-                  secure: isSecure,
-                  sameSite: 'strict',
-                  path: '/',
-                  maxAge: COOKIE_MAX_AGE.REFRESH_TOKEN,
-                })
-              }
-
-              return res
-            }
-          }
-        }
-      }
-
-      return createNoCacheResponse(
-        {
-          error: data.message || data.error?.message || '決済履歴の取得に失敗しました',
-        },
-        { status: response.status }
-      )
-    }
-
-    return createNoCacheResponse(data)
+    return response
   } catch (error) {
     console.error('❌ [payment-history] Route error:', error)
     return createNoCacheResponse(

--- a/frontend/src/app/api/user/usage-history/route.ts
+++ b/frontend/src/app/api/user/usage-history/route.ts
@@ -1,8 +1,6 @@
 import { NextRequest } from 'next/server'
 import { buildApiUrl } from '@/lib/api-config'
-import { getRefreshToken } from '@/lib/auth-header'
-import { COOKIE_MAX_AGE, COOKIE_NAMES } from '@/lib/cookie-config'
-import { secureFetchWithCommonHeaders } from '@/lib/fetch-utils'
+import { authenticatedFetch } from '@/lib/auth-fetch'
 import { createNoCacheResponse } from '@/lib/response-utils'
 
 export const dynamic = 'force-dynamic'
@@ -11,120 +9,11 @@ export async function GET(request: NextRequest) {
   try {
     const fullUrl = buildApiUrl('/users/me/usage-history')
 
-    const response = await secureFetchWithCommonHeaders(request, fullUrl, {
+    const { response } = await authenticatedFetch(request, fullUrl, {
       method: 'GET',
-      headerOptions: {
-        requireAuth: true, // 認証が必要
-      },
     })
 
-    // 認証エラーの場合は401を返す
-    if (response.status === 401) {
-      return createNoCacheResponse(
-        { error: '認証が必要です' },
-        { status: 401 }
-      )
-    }
-
-    const data = await response.json()
-
-    if (!response.ok) {
-      console.error('❌ [usage-history] Backend API error:', data)
-      
-      // 401または403エラーの場合、リフレッシュトークンで再試行
-      if (response.status === 401 || response.status === 403) {
-        const refreshToken = getRefreshToken(request)
-        
-        if (refreshToken) {
-          // リフレッシュトークンでトークン更新
-          const refreshUrl = buildApiUrl('/refresh')
-          const refreshResponse = await secureFetchWithCommonHeaders(request, refreshUrl, {
-            method: 'POST',
-            headerOptions: {
-              requireAuth: false, // リフレッシュトークンは認証不要
-            },
-            body: JSON.stringify({ refreshToken }),
-          })
-          
-          if (refreshResponse.ok) {
-            const refreshData = await refreshResponse.json()
-            
-            // リフレッシュ成功、新しいトークンで元のリクエストを再試行
-            const newAuthHeader = `Bearer ${refreshData.accessToken}`
-            const retryResponse = await secureFetchWithCommonHeaders(request, fullUrl, {
-              method: 'GET',
-              headerOptions: {
-                requireAuth: true,
-                customHeaders: {
-                  'Authorization': newAuthHeader,
-                },
-              },
-            })
-            
-            if (retryResponse.ok) {
-              const retryData = await retryResponse.json()
-              // リフレッシュされたトークンをCookieに反映
-              const res = createNoCacheResponse(retryData, { status: 200 })
-              const isSecure = (() => {
-                try { return new URL(request.url).protocol === 'https:'; } catch { return process.env.NODE_ENV === 'production'; }
-              })()
-              
-              // 新しいトークンをCookieに設定
-              if (refreshData.accessToken) {
-                // 旧Cookie（プレフィックス無し）を削除して衝突を解消
-                res.cookies.set('accessToken', '', { httpOnly: true, secure: isSecure, sameSite: 'strict', path: '/', maxAge: 0 })
-                res.cookies.set('__Host-accessToken', '', { httpOnly: true, secure: isSecure, sameSite: 'strict', path: '/', maxAge: 0 })
-
-                res.cookies.set(COOKIE_NAMES.ACCESS_TOKEN, refreshData.accessToken, {
-                  httpOnly: true,
-                  secure: isSecure,
-                  sameSite: 'strict',
-                  path: '/',
-                  maxAge: COOKIE_MAX_AGE.ACCESS_TOKEN, // 環境変数JWT_ACCESS_TOKEN_EXPIRES_INから取得（cookie-config.tsで一元管理）
-                })
-                res.cookies.set(COOKIE_NAMES.HOST_ACCESS_TOKEN, refreshData.accessToken, {
-                  httpOnly: true,
-                  secure: isSecure,
-                  sameSite: 'strict',
-                  path: '/',
-                  maxAge: COOKIE_MAX_AGE.ACCESS_TOKEN, // 環境変数JWT_ACCESS_TOKEN_EXPIRES_INから取得（cookie-config.tsで一元管理）
-                })
-              }
-              if (refreshData.refreshToken) {
-                // 旧Cookie（プレフィックス無し）を削除して衝突を解消
-                res.cookies.set('refreshToken', '', { httpOnly: true, secure: isSecure, sameSite: 'strict', path: '/', maxAge: 0 })
-                res.cookies.set('__Host-refreshToken', '', { httpOnly: true, secure: isSecure, sameSite: 'strict', path: '/', maxAge: 0 })
-
-                res.cookies.set(COOKIE_NAMES.REFRESH_TOKEN, refreshData.refreshToken, {
-                  httpOnly: true,
-                  secure: isSecure,
-                  sameSite: 'strict',
-                  path: '/',
-                  maxAge: COOKIE_MAX_AGE.REFRESH_TOKEN, // 環境変数JWT_REFRESH_TOKEN_EXPIRES_INから取得（cookie-config.tsで一元管理）
-                })
-                res.cookies.set(COOKIE_NAMES.HOST_REFRESH_TOKEN, refreshData.refreshToken, {
-                  httpOnly: true,
-                  secure: isSecure,
-                  sameSite: 'strict',
-                  path: '/',
-                  maxAge: COOKIE_MAX_AGE.REFRESH_TOKEN, // 環境変数JWT_REFRESH_TOKEN_EXPIRES_INから取得（cookie-config.tsで一元管理）
-                })
-              }
-              
-              return res
-            }
-          }
-        }
-      }
-      
-      return createNoCacheResponse(
-        { error: data.message || data.error?.message || '利用履歴の取得に失敗しました' },
-        { status: response.status }
-      )
-    }
-    
-    return createNoCacheResponse(data)
-
+    return response
   } catch (error) {
     console.error('❌ [usage-history] Route error:', error)
     return createNoCacheResponse(

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -60,21 +60,8 @@ export function useAuth() {
         }
     }, []);
 
-    // リフレッシュトークンでアクセストークンを更新する
-    const tryRefresh = useCallback(async (): Promise<boolean> => {
-        try {
-            const res = await fetch('/api/auth/refresh', {
-                method: 'POST',
-                credentials: 'include',
-            });
-            return res.ok;
-        } catch (error) {
-            console.error('トークンリフレッシュに失敗しました:', error);
-            return false;
-        }
-    }, []);
-
     // ユーザー情報を取得する
+    // サーバーサイドで自動リフレッシュが行われるため、クライアント側でのリフレッシュは不要
     const fetchUserMe = useCallback(async (): Promise<{ status: number; data: User | null }> => {
         try {
             const response = await fetch('/api/user/me', {
@@ -91,7 +78,7 @@ export function useAuth() {
         }
     }, []);
 
-    // 自動ログイン処理とトークンチェック
+    // 認証初期化
     useEffect(() => {
         if (typeof window !== 'undefined' && !hasInitialized.current) {
             hasInitialized.current = true;
@@ -100,40 +87,22 @@ export function useAuth() {
             const loginEmail = urlParams.get('email');
 
             if (autoLogin === 'true' && loginEmail) {
-                // 自動ログイン処理
                 setIsAuthenticated(true);
-                // URLパラメータをクリア
                 window.history.replaceState({}, '', '/');
             } else {
-                // Cookieにアクセストークンがある場合は認証済みとする
-                // Cookieは自動的に送信されるため、Authorizationヘッダーは不要
                 setIsLoading(true);
                 
                 const initAuth = async () => {
                     try {
-                        let result = await fetchUserMe();
-                        
-                        // 401/403エラーの場合はリフレッシュを試みる
-                        if (result.status === 401 || result.status === 403) {
-                            console.log('🔄 アクセストークン期限切れ、リフレッシュを試行中...');
-                            const refreshed = await tryRefresh();
-                            if (refreshed) {
-                                console.log('✅ トークンリフレッシュ成功、ユーザー情報を再取得中...');
-                                result = await fetchUserMe();
-                            } else {
-                                console.log('❌ トークンリフレッシュ失敗');
-                            }
-                        }
+                        const result = await fetchUserMe();
                         
                         if (result.data) {
                             setIsAuthenticated(true);
                             setUser(result.data);
                             setPlan(result.data.plan);
-                            // 利用履歴は別途APIから取得
                             fetchUsageHistory();
                             setPaymentHistory(result.data.paymentHistory || []);
                         } else {
-                            // トークンが無効な場合は未認証とする
                             setIsAuthenticated(false);
                         }
                     } catch (error) {
@@ -147,7 +116,7 @@ export function useAuth() {
                 initAuth();
             }
         }
-    }, [fetchUsageHistory, fetchUserMe, tryRefresh]);
+    }, [fetchUsageHistory, fetchUserMe]);
 
     const login = (userData: User, planData: Plan | undefined, usage: UsageHistory[], payment: PaymentHistory[]) => {
         setIsAuthenticated(true);

--- a/frontend/src/lib/auth-fetch.ts
+++ b/frontend/src/lib/auth-fetch.ts
@@ -1,0 +1,111 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { buildApiUrl } from '@/lib/api-config'
+import { getRefreshToken } from '@/lib/auth-header'
+import { secureFetchWithCommonHeaders } from '@/lib/fetch-utils'
+import { createNoCacheResponse } from '@/lib/response-utils'
+import { setTokenCookies, isSecureRequest, type TokenPair } from '@/lib/token-cookie'
+import type { HeaderOptions } from '@/lib/header-utils'
+
+export interface AuthFetchResult {
+  response: NextResponse
+  /** リフレッシュが実行されて成功したかどうか */
+  refreshed: boolean
+}
+
+/**
+ * 認証付きfetch + 自動リフレッシュ（サーバーサイドAPI Route用）
+ *
+ * 1. 認証ヘッダー付きでバックエンドAPIにリクエスト
+ * 2. 401/403 → リフレッシュトークンで自動更新を試行
+ * 3. 成功 → 新トークンをCookieにセットし、元のリクエストをリトライ
+ *
+ * @returns { response, refreshed } responseはそのまま返却可能なNextResponse
+ */
+export async function authenticatedFetch(
+  request: NextRequest,
+  url: string,
+  options: RequestInit & { headerOptions?: HeaderOptions } = {}
+): Promise<AuthFetchResult> {
+  const response = await secureFetchWithCommonHeaders(request, url, {
+    ...options,
+    headerOptions: {
+      requireAuth: true,
+      ...options.headerOptions,
+    },
+  })
+
+  if (response.status !== 401 && response.status !== 403) {
+    const data = await response.json()
+    return {
+      response: createNoCacheResponse(
+        response.ok ? data : { error: data.message || data.error?.message || 'リクエストに失敗しました' },
+        { status: response.status }
+      ),
+      refreshed: false,
+    }
+  }
+
+  const refreshToken = getRefreshToken(request)
+  if (!refreshToken) {
+    return {
+      response: createNoCacheResponse(
+        { error: '認証が必要です' },
+        { status: 401 }
+      ),
+      refreshed: false,
+    }
+  }
+
+  const refreshUrl = buildApiUrl('/refresh')
+  const refreshResponse = await secureFetchWithCommonHeaders(request, refreshUrl, {
+    method: 'POST',
+    headerOptions: { requireAuth: false },
+    body: JSON.stringify({ refreshToken }),
+  })
+
+  if (!refreshResponse.ok) {
+    return {
+      response: createNoCacheResponse(
+        { error: '認証トークンが無効です。再度ログインしてください。' },
+        { status: 401 }
+      ),
+      refreshed: false,
+    }
+  }
+
+  const refreshData = await refreshResponse.json() as TokenPair
+
+  const newAuthHeader = `Bearer ${refreshData.accessToken}`
+  const retryResponse = await secureFetchWithCommonHeaders(request, url, {
+    ...options,
+    headerOptions: {
+      ...options.headerOptions,
+      requireAuth: true,
+      customHeaders: {
+        ...options.headerOptions?.customHeaders,
+        Authorization: newAuthHeader,
+      },
+    },
+  })
+
+  const retryData = await retryResponse.json()
+
+  if (!retryResponse.ok) {
+    return {
+      response: createNoCacheResponse(
+        { error: retryData.message || retryData.error?.message || 'リクエストに失敗しました' },
+        { status: retryResponse.status }
+      ),
+      refreshed: false,
+    }
+  }
+
+  const nextResponse = createNoCacheResponse(retryData, { status: 200 })
+  const isSecure = isSecureRequest(request)
+  setTokenCookies(nextResponse, refreshData, isSecure)
+
+  return {
+    response: nextResponse,
+    refreshed: true,
+  }
+}

--- a/frontend/src/lib/token-cookie.ts
+++ b/frontend/src/lib/token-cookie.ts
@@ -1,0 +1,100 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { COOKIE_MAX_AGE, COOKIE_NAMES } from '@/lib/cookie-config'
+
+export interface TokenPair {
+  accessToken?: string
+  refreshToken?: string
+}
+
+/**
+ * リクエストURLからHTTPS判定を行う
+ */
+export function isSecureRequest(request: NextRequest): boolean {
+  try {
+    return new URL(request.url).protocol === 'https:'
+  } catch {
+    return process.env.NODE_ENV === 'production'
+  }
+}
+
+/**
+ * トークンをhttpOnly Cookieに設定する（一元管理）
+ *
+ * - 旧Cookie（プレフィックス無し）を削除して衝突を解消
+ * - 通常Cookie + __Host-プレフィックス付きCookie（HTTPS時のみ）を設定
+ */
+export function setTokenCookies(
+  response: NextResponse,
+  tokens: TokenPair,
+  isSecure: boolean
+): void {
+  if (tokens.accessToken) {
+    response.cookies.set('accessToken', '', { httpOnly: true, secure: isSecure, sameSite: 'strict', path: '/', maxAge: 0 })
+    response.cookies.set('__Host-accessToken', '', { httpOnly: true, secure: isSecure, sameSite: 'strict', path: '/', maxAge: 0 })
+
+    response.cookies.set(COOKIE_NAMES.ACCESS_TOKEN, tokens.accessToken, {
+      httpOnly: true,
+      secure: isSecure,
+      sameSite: 'strict',
+      path: '/',
+      maxAge: COOKIE_MAX_AGE.ACCESS_TOKEN,
+    })
+    if (isSecure) {
+      response.cookies.set(COOKIE_NAMES.HOST_ACCESS_TOKEN, tokens.accessToken, {
+        httpOnly: true,
+        secure: true,
+        sameSite: 'strict',
+        path: '/',
+        maxAge: COOKIE_MAX_AGE.ACCESS_TOKEN,
+      })
+    }
+  }
+
+  if (tokens.refreshToken) {
+    response.cookies.set('refreshToken', '', { httpOnly: true, secure: isSecure, sameSite: 'strict', path: '/', maxAge: 0 })
+    response.cookies.set('__Host-refreshToken', '', { httpOnly: true, secure: isSecure, sameSite: 'strict', path: '/', maxAge: 0 })
+
+    response.cookies.set(COOKIE_NAMES.REFRESH_TOKEN, tokens.refreshToken, {
+      httpOnly: true,
+      secure: isSecure,
+      sameSite: 'strict',
+      path: '/',
+      maxAge: COOKIE_MAX_AGE.REFRESH_TOKEN,
+    })
+    if (isSecure) {
+      response.cookies.set(COOKIE_NAMES.HOST_REFRESH_TOKEN, tokens.refreshToken, {
+        httpOnly: true,
+        secure: true,
+        sameSite: 'strict',
+        path: '/',
+        maxAge: COOKIE_MAX_AGE.REFRESH_TOKEN,
+      })
+    }
+  }
+}
+
+/**
+ * トークンCookieをすべて削除する（ログアウト用、一元管理）
+ */
+export function clearTokenCookies(
+  response: NextResponse,
+  isSecure: boolean
+): void {
+  const cookieOptions = {
+    httpOnly: true,
+    secure: isSecure,
+    sameSite: 'strict' as const,
+    path: '/',
+    maxAge: 0,
+  }
+
+  response.cookies.set(COOKIE_NAMES.ACCESS_TOKEN, '', cookieOptions)
+  response.cookies.set(COOKIE_NAMES.HOST_ACCESS_TOKEN, '', cookieOptions)
+  response.cookies.set(COOKIE_NAMES.REFRESH_TOKEN, '', cookieOptions)
+  response.cookies.set(COOKIE_NAMES.HOST_REFRESH_TOKEN, '', cookieOptions)
+
+  response.cookies.set('accessToken', '', cookieOptions)
+  response.cookies.set('__Host-accessToken', '', cookieOptions)
+  response.cookies.set('refreshToken', '', cookieOptions)
+  response.cookies.set('__Host-refreshToken', '', cookieOptions)
+}

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -167,21 +167,25 @@ export async function middleware(request: NextRequest) {
   ]
 
   if (protectedPaths.some(p => pathname === p || pathname.startsWith(`${p}/`))) {
-    const token =
+    const hasAccessToken =
       request.cookies.get(COOKIE_NAMES.ACCESS_TOKEN)?.value ||
       request.cookies.get(COOKIE_NAMES.HOST_ACCESS_TOKEN)?.value
-    if (!token) {
+    const hasRefreshToken =
+      request.cookies.get(COOKIE_NAMES.REFRESH_TOKEN)?.value ||
+      request.cookies.get(COOKIE_NAMES.HOST_REFRESH_TOKEN)?.value
+
+    if (!hasAccessToken && !hasRefreshToken) {
       const url = request.nextUrl.clone()
       url.pathname = '/login'
       url.searchParams.set('session', 'expired')
       const redirectResponse = NextResponse.redirect(url)
-      // リダイレクトレスポンスにもキャッシュ無効化ヘッダーを設定
       redirectResponse.headers.set('Cache-Control', 'no-store, no-cache, must-revalidate, private')
       redirectResponse.headers.set('Pragma', 'no-cache')
       redirectResponse.headers.set('Expires', '0')
       return redirectResponse
     }
-    // 署名検証はAPI層で実施。ここではCookieの存在のみでガード。
+    // 署名検証・リフレッシュはAPI層（authenticatedFetch）で実施。
+    // ここではいずれかのトークンCookieが存在すれば通過させる。
   }
 
   const response = NextResponse.next()


### PR DESCRIPTION
## 背景 / 目的

本番環境で「ログイン後数時間でログアウトされる」不具合が発生していた。

調査の結果、以下2つの問題を特定した：

1. **`/api/auth/login/route.ts` でトークンをCookieに保存する処理が実装されていなかった**
   - パスワードログイン時、APIからのレスポンス（accessToken, refreshToken）がCookieに保存されず、アクセストークン期限切れ後にリフレッシュ不可→ログアウトされていた
   - 本番ログで `GET /api/user/me → 401` → `POST /api/auth/refresh → 400`（リフレッシュトークンCookieが存在しない）のパターンを確認

2. **トークンCookie設定処理が7ファイル以上にコピペで散在**しており、1箇所でも漏れると上記のような不具合が発生する構造的な問題があった

## 変更概要

### 新規ファイル（共通ユーティリティ）
- **`src/lib/token-cookie.ts`**: `setTokenCookies` / `clearTokenCookies` / `isSecureRequest`
  - トークンCookieの設定・削除を一元管理（旧Cookie削除 + 通常Cookie + __Host-Cookie）
- **`src/lib/auth-fetch.ts`**: `authenticatedFetch`
  - 認証付きfetch + 401時の自動リフレッシュ + Cookie再設定を一元管理

### バグ修正
- **`/api/auth/login/route.ts`**: `setTokenCookies` でCookie保存処理を追加

### リファクタリング（Cookie設定の共通化）
- `/api/auth/verify-otp/route.ts` → `setTokenCookies` に置き換え
- `/api/auth/refresh/route.ts` → `setTokenCookies` に置き換え
- `/api/auth/register/route.ts` → `setTokenCookies` に置き換え
- `/api/auth/logout/route.ts` → `clearTokenCookies` に置き換え

### リファクタリング（リフレッシュ処理の共通化）
- `/api/user/me/route.ts` → 独自リフレッシュ処理を削除、`authenticatedFetch` に置き換え
- `/api/user/usage-history/route.ts` → 同上
- `/api/user/payment-history/route.ts` → 同上
- `/api/auth/password/change/route.ts` → 同上
- `/api/auth/email/change/route.ts` → 同上

### クライアント側
- `hooks/useAuth.ts` → クライアント側の `tryRefresh` を削除（サーバーサイドで自動リフレッシュされるため不要）

### ミドルウェア
- `middleware.ts` → 保護ページのチェックをアクセストークン**または**リフレッシュトークンの存在で判定するよう変更（アクセストークンCookieが期限切れでもリフレッシュトークンがあれば通過→API層でリフレッシュ）

## 影響範囲

- パスワードログインのフロー
- OTPログインのフロー（動作変更なし、内部リファクタリングのみ）
- トークンリフレッシュのフロー
- 認証が必要な全APIエンドポイント（me, usage-history, payment-history, password/change, email/change）
- ログアウト処理
- 保護ページへのアクセス時の認証チェック

## テスト

- [ ] パスワードログイン後、Cookie（accessToken, refreshToken）がブラウザに保存されること
- [ ] OTPログイン後、Cookie（accessToken, refreshToken）がブラウザに保存されること
- [ ] アクセストークン期限切れ後、保護ページにアクセスしてもログアウトされないこと
- [ ] アクセストークン期限切れ後、APIリクエストが自動リフレッシュで成功すること
- [ ] リフレッシュトークンも期限切れの場合、ログイン画面にリダイレクトされること
- [ ] ログアウト操作で全Cookieが削除されること
- [ ] 新規登録後、Cookie（accessToken, refreshToken）がブラウザに保存されること
