### PR TITLE
継続課金変更APIに userPlanId を必須化

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
-    "@hv-development/schemas": "1.122.0",
+    "@hv-development/schemas": "1.123.0",
     "@radix-ui/react-accordion": "1.2.2",
     "@radix-ui/react-alert-dialog": "1.1.4",
     "@radix-ui/react-aspect-ratio": "1.1.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -13,8 +13,8 @@ dependencies:
     specifier: ^3.10.0
     version: 3.10.0(react-hook-form@7.68.0)
   '@hv-development/schemas':
-    specifier: 1.122.0
-    version: 1.122.0
+    specifier: 1.123.0
+    version: 1.123.0
   '@radix-ui/react-accordion':
     specifier: 1.2.2
     version: 1.2.2(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1)
@@ -235,24 +235,24 @@ packages:
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
     engines: {node: '>=6.9.0'}
 
-  /@emnapi/core@1.9.1:
-    resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
+  /@emnapi/core@1.10.0:
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
     requiresBuild: true
     dependencies:
-      '@emnapi/wasi-threads': 1.2.0
+      '@emnapi/wasi-threads': 1.2.1
       tslib: 2.8.1
     dev: true
     optional: true
 
-  /@emnapi/runtime@1.9.1:
-    resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
+  /@emnapi/runtime@1.10.0:
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
     requiresBuild: true
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  /@emnapi/wasi-threads@1.2.0:
-    resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
+  /@emnapi/wasi-threads@1.2.1:
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
     requiresBuild: true
     dependencies:
       tslib: 2.8.1
@@ -579,8 +579,8 @@ packages:
     deprecated: Use @eslint/object-schema instead
     dev: true
 
-  /@hv-development/schemas@1.122.0:
-    resolution: {integrity: sha512-nBks6iPhPKP6BJd0nhwrG0wCEWyKKovBbJvPkBqEOoVbdwRMHBgywZ3C/flCgWL2k1vtyz3//GRbCGPkdV/C/w==, tarball: https://npm.pkg.github.com/download/@hv-development/schemas/1.122.0/0a5ad1b09e986291411df6737c003a2d8dc9ca62}
+  /@hv-development/schemas@1.123.0:
+    resolution: {integrity: sha512-1FXPHR3BEJSF34oqvIEDx1btisBnyJ18r+c3n1+rCuiwuQeYjfmN9ym8E6ETkfHAWrekEaIMhguCrnNXSNL3Kg==, tarball: https://npm.pkg.github.com/download/@hv-development/schemas/1.123.0/cb7648a0e82fe6004fc427f3a592e6dbd5d5b48e}
     engines: {node: 22.x}
     dependencies:
       zod: 3.25.76
@@ -767,7 +767,7 @@ packages:
     cpu: [wasm32]
     requiresBuild: true
     dependencies:
-      '@emnapi/runtime': 1.9.1
+      '@emnapi/runtime': 1.10.0
     optional: true
 
   /@img/sharp-win32-arm64@0.34.5:
@@ -829,8 +829,8 @@ packages:
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
     requiresBuild: true
     dependencies:
-      '@emnapi/core': 1.9.1
-      '@emnapi/runtime': 1.9.1
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.1
     dev: true
     optional: true

--- a/frontend/src/app/api/payment/update/route.ts
+++ b/frontend/src/app/api/payment/update/route.ts
@@ -9,6 +9,7 @@ export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
     const {
+      userPlanId,
       customerId,
       customerCardId,
       planId,
@@ -20,6 +21,17 @@ export async function POST(request: NextRequest) {
     } = body
 
     const fullUrl = buildApiUrl('/payment/update')
+
+    if (
+      typeof userPlanId !== 'string' ||
+      userPlanId.length === 0 ||
+      userPlanId.length > 64
+    ) {
+      return createNoCacheResponse(
+        { error: 'userPlanId（ユーザープランID）を指定してください。' },
+        { status: 400 }
+      )
+    }
 
     // amountもendScheduledも指定されていない場合はエラー
     if (amount === undefined && endScheduled === undefined) {
@@ -39,7 +51,9 @@ export async function POST(request: NextRequest) {
 
     // undefinedのフィールドを除外してバックエンドに送信
     // セキュリティ改善：userEmailはバックエンドで認証トークンから取得するため、フロントエンドから送信しない
-    const backendRequestBody: Record<string, unknown> = {}
+    const backendRequestBody: Record<string, unknown> = {
+      userPlanId,
+    }
 
     if (customerId) {
       backendRequestBody.customerId = customerId

--- a/frontend/src/hooks/useAppHandlers.ts
+++ b/frontend/src/hooks/useAppHandlers.ts
@@ -778,37 +778,49 @@ export const useAppHandlers = (
                 throw new Error(errorData.message || 'プラン変更に失敗しました')
             }
 
-            const _responseData = await response.json();
+            const responseData = await response.json();
+
+            // 単発プランへの切替の場合（旧継続課金はバックエンド側で解約済み）
+            if (responseData.change_kind === 'single_plan_qr') {
+                try {
+                    const userResponse = await fetch('/api/user/me', {
+                        credentials: 'include',
+                        cache: 'no-store',
+                    })
+                    if (userResponse.ok) {
+                        const updatedUserData = await userResponse.json()
+                        auth.login(updatedUserData, updatedUserData.plan, updatedUserData.usageHistory || [], updatedUserData.paymentHistory || [])
+                    }
+                } catch (userError) {
+                    console.error('❌ [handlePlanChangeSubmit] ユーザー情報取得エラー:', userError);
+                }
+                navigation.navigateToMyPage("main")
+                return
+            }
 
             // プラン変更後、新しいユーザー情報を取得してauth状態を更新
             try {
                 const userResponse = await fetch('/api/user/me', {
-                    credentials: 'include', // Cookieを送信
+                    credentials: 'include',
+                    cache: 'no-store',
                 })
 
                 if (userResponse.ok) {
                     const updatedUserData = await userResponse.json()
 
-                    // auth状態を更新
                     auth.login(updatedUserData, updatedUserData.plan, updatedUserData.usageHistory || [], updatedUserData.paymentHistory || [])
                 }
             } catch (userError) {
                 console.error('❌ [handlePlanChangeSubmit] ユーザー情報取得エラー:', userError);
-                // プラン変更は成功しているので、エラーでも続行
             }
-
-            // 支払い方法も変更する場合は、支払い方法変更確認画面へ遷移
 
             if (alsoChangePaymentMethod) {
                 if (typeof window !== 'undefined') {
-                    // 支払い方法変更確認画面へ遷移（カード登録APIは、確認画面で「カード情報を変更する」ボタンをクリックしたときに呼び出される）
-                    // プラン変更時の新しいplanIdをURLパラメータとして渡す
                     window.location.href = `/payment-method-change?from=plan-change&planId=${encodeURIComponent(planId)}`;
                 } else {
                     console.warn('⚠️ [handlePlanChangeSubmit] windowが定義されていません');
                 }
             } else {
-                // 成功時はマイページに戻る
                 navigation.navigateToMyPage("main")
             }
 
@@ -937,6 +949,12 @@ export const useAppHandlers = (
 
             const endScheduled = formatDate(nextBillingDate)
 
+            if (!userPlanId) {
+                throw new Error(
+                    'ユーザープラン情報を取得できませんでした。マイページを再読み込みしてから再度お試しください。'
+                )
+            }
+
             // 退会処理APIを呼び出し（Paygent継続課金ありの場合）
             // userEmailはバックエンドで認証トークンから取得するため、送信しない
             const response = await fetch('/api/payment/update', {
@@ -945,6 +963,7 @@ export const useAppHandlers = (
                     'Content-Type': 'application/json',
                 },
                 body: JSON.stringify({
+                    userPlanId,
                     customerId: user.paymentCard?.paygentCustomerId,
                     customerCardId: user.paymentCard?.paygentCustomerCardId,
                     runningId: runningId,

--- a/frontend/src/hooks/usePaymentMethodChange.ts
+++ b/frontend/src/hooks/usePaymentMethodChange.ts
@@ -90,12 +90,19 @@ export const usePaymentMethodChange = () => {
           if (currentAmount == null || currentAmount === undefined) {
             throw new Error('現在のプラン情報を取得できません。プランに加入後に支払方法の変更を行ってください。')
           }
+          const userPlanId = userPlan?.id
+          if (!userPlanId) {
+            throw new Error(
+              'ユーザープラン情報を取得できませんでした。マイページを再読み込みしてから再度お試しください。'
+            )
+          }
           const response = await fetch('/api/payment/update', {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
             },
             body: JSON.stringify({
+              userPlanId,
               customerId: mockCustomerId,
               customerCardId: mockCustomerCardId,
               runningId,


### PR DESCRIPTION
**背景 / 目的**

Paygent 継続課金変更（電文 281）完了後の DB 更新で、UserPlan の特定が曖昧になり、endScheduledDate などが更新されない事象があった。
amount の有無だけで対象 UserPlan を推測するのは分かりにくく、誤更新・未更新のリスクがある。
クライアントから対象を明示する userPlanId を必須にし、サーバー側で ドメイン・customerId・runningId と整合検証することで、正しいレコード更新と IDOR 対策を両立する。

**変更概要**
@hv-development/schemas（tamanomi-schemas）
UpdateRecurringPaymentRequest に userPlanId（必須・文字列） を追加。
JSON Schema / バリデーション定義を required: ['userPlanId'] に合わせて更新。
UpdateRecurringPaymentServiceParams 等の型に userPlanId を反映。
tamanomi-api
RecurringPaymentUpdateService
assertUserPlanForRecurringUpdate / assertUserPlanForFreePeriodUpdate で userPlanId と domain / customerId / runningId の整合を検証。
getUserByCustomerId の例外は FORBIDDEN（403） に寄せる。
RecurringPaymentController
無料期間用エンドポイントでも USER_PLAN_NOT_FOUND（404） / FORBIDDEN（403） を返却。
プラン変更フロー（user-plans.controller / app-link-plan-change.service）の内部呼び出しで UpdateRecurringPaymentRequest に userPlanId（pending 側の UserPlan ID）を付与。
依存: @hv-development/schemas をスキーマ変更に追従（ローカルは file:../tamanomi-schemas、本番リリース前にパッケージ公開とバージョン固定を推奨）。
tamanomi-web / nomoca-kagawa-web
/api/payment/update（Next.js Route）
userPlanId を必須検証し、バックエンドへ転送。
useAppHandlers（退会・Paygent 継続課金あり）
userPlanId 未取得時はエラー、取得時は /api/payment/update の body に付与。
usePaymentMethodChange（モックの支払方法変更）
同様に userPlanId を付与。