### PR TITLE
fix: クーポン一覧でタイトルが表示されない問題を修正

### DIFF
--- a/frontend/src/components/molecules/CouponCard.tsx
+++ b/frontend/src/components/molecules/CouponCard.tsx
@@ -38,7 +38,7 @@ export function CouponCard({ coupon, onUse, className = "" }: CouponCardProps) {
         <div className="relative h-48 overflow-hidden">
           <Image 
             src={displayImage!} 
-            alt={coupon.title} 
+            alt={coupon.name} 
             fill 
             className="object-cover object-center" 
             onError={() => setIsImageError(true)}
@@ -49,7 +49,7 @@ export function CouponCard({ coupon, onUse, className = "" }: CouponCardProps) {
       {/* クーポン情報 */}
       <div className="p-5 space-y-4">
         <div>
-          <h3 className="font-bold text-xl text-gray-900 mb-2">{coupon.title}</h3>
+          <h3 className="font-bold text-xl text-gray-900 mb-2">{coupon.name}</h3>
           <p className="text-sm text-gray-600 leading-relaxed">{coupon.description}</p>
         </div>
 

--- a/frontend/src/components/molecules/CouponConfirmationPage.tsx
+++ b/frontend/src/components/molecules/CouponConfirmationPage.tsx
@@ -55,7 +55,7 @@ export default function CouponConfirmationPage({
                 <div className="w-full h-64 overflow-hidden relative">
                   <Image
                     src={coupon.imageUrl || getDefaultCouponImage(coupon.drinkType) || "/placeholder.svg"}
-                    alt={coupon.title}
+                    alt={coupon.name}
                     fill
                     className="object-cover object-center"
                   />
@@ -66,7 +66,7 @@ export default function CouponConfirmationPage({
                   {/* クーポン名 */}
                   <div className="text-left mb-4">
                     <h4 className="font-bold text-2xl text-gray-900 break-all">
-                      {coupon.title}
+                      {coupon.name}
                     </h4>
                   </div>
 

--- a/frontend/src/components/molecules/CouponConfirmationPopup.tsx
+++ b/frontend/src/components/molecules/CouponConfirmationPopup.tsx
@@ -61,13 +61,13 @@ export function CouponConfirmationPopup({ isOpen, coupon, onConfirm, onCancel }:
                   <div className="flex-shrink-0 relative w-20 h-20">
                     <Image
                       src={coupon.imageUrl || getDefaultCouponImage(coupon.drinkType) || "/placeholder.svg"}
-                      alt={coupon.title}
+                      alt={coupon.name}
                       fill
                       className="rounded-xl object-cover border border-gray-300"
                     />
                   </div>
                   <div className="flex-1 min-w-0">
-                    <h4 className="font-bold text-lg text-gray-900 mb-1">{coupon.title}</h4>
+                    <h4 className="font-bold text-lg text-gray-900 mb-1">{coupon.name}</h4>
                     <p className="text-sm text-gray-600">{coupon.storeName}</p>
                   </div>
                 </div>

--- a/frontend/src/components/molecules/CouponListPopup.tsx
+++ b/frontend/src/components/molecules/CouponListPopup.tsx
@@ -152,7 +152,7 @@ export function CouponListPopup({ isOpen, storeName, coupons, onClose, onUseCoup
                         <div className="w-full h-48 overflow-hidden relative">
                           <Image
                             src={displayImage!}
-                            alt={coupon.title}
+                            alt={coupon.name}
                             fill
                             className="object-cover object-center"
                             onError={() => handleImageError(coupon.id)}
@@ -163,7 +163,7 @@ export function CouponListPopup({ isOpen, storeName, coupons, onClose, onUseCoup
                       {/* クーポン情報 */}
                       <div className="p-4">
                         <h4 className="font-bold text-lg text-gray-900 mb-2 text-left break-all">
-                          {coupon.title}
+                          {coupon.name}
                         </h4>
                         <p className="text-base text-gray-900 leading-relaxed mb-4 text-left font-medium break-all">
                           {coupon.description}

--- a/frontend/src/components/molecules/CouponUsedSuccessModal.tsx
+++ b/frontend/src/components/molecules/CouponUsedSuccessModal.tsx
@@ -73,7 +73,7 @@ export function CouponUsedSuccessModal({ isOpen, coupon, onClose }: CouponUsedSu
               </h4>
 
               <div className="space-y-2">
-                <p className="text-green-700 font-medium">{coupon.title}</p>
+                <p className="text-green-700 font-medium">{coupon.name}</p>
                 <p className="text-sm text-gray-600">{coupon.storeName}</p>
               </div>
 

--- a/frontend/src/components/templates/HomeLayout.tsx
+++ b/frontend/src/components/templates/HomeLayout.tsx
@@ -242,7 +242,7 @@ export function HomeLayout({ onMount }: HomeLayoutProps) {
     return {
       id: coupon.id,
       uuid: coupon.id,
-      title: coupon.title,
+      name: coupon.title,
       description: coupon.description,
       conditions: coupon.conditions,
       imageUrl: coupon.imageUrl,

--- a/frontend/src/hooks/useAppHandlers.ts
+++ b/frontend/src/hooks/useAppHandlers.ts
@@ -644,7 +644,7 @@ export const useAppHandlers = (
                         updatedAt?: string;
                     }) => ({
                         id: coupon.id,
-                        title: coupon.title,
+                        name: coupon.title,
                         description: coupon.description || '',
                         conditions: coupon.conditions || null,
                         imageUrl: coupon.imageUrl || '',


### PR DESCRIPTION
APIレスポンスの `title` フィールドをCouponUiの `name` フィールドに
正しくマッピングするよう修正。nomoca-kagawa-webと同様の実装に統一。

- CouponListPopup: coupon.title → coupon.name
- CouponCard: coupon.title → coupon.name
- CouponConfirmationPopup: coupon.title → coupon.name
- CouponConfirmationPage: coupon.title → coupon.name
- CouponUsedSuccessModal: coupon.title → coupon.name
- useAppHandlers: マッピング title → name に修正
- HomeLayout: マッピング title → name に修正

Made-with: Cursor