### PR TITLE
125-111：TOP / LP　meta description変更

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -42,7 +42,7 @@ const rubik = Rubik({
 
 export const metadata: Metadata = {
   title: 'たまのみ - 毎日1杯無料で乾杯',
-  description: 'さいたま市のお店で使える便利でお得なサービス「たまのみ」。対象の飲食店で毎日ドリンクが1杯無料になる"Welcomeドリンク"サービスです。',
+  description: '毎日一軒ごとにドリンク一杯が無料に！さいたま市の飲食店で使えるちょっとお得な"Welcomeドリンク"サービスたまのみをご利用ください。',
   icons: {
     icon: [
       { url: '/favicon.png', type: 'image/png' },

--- a/frontend/src/app/lp/layout.tsx
+++ b/frontend/src/app/lp/layout.tsx
@@ -4,7 +4,7 @@ import { LpFlowButton } from '@/components/atoms/LpFlowButton'
 
 export const metadata: Metadata = {
   title: 'たまのみ - 毎日1杯無料で乾杯',
-  description: 'さいたま市のお店で使える便利でお得なサービス「たまのみ」。対象の飲食店で毎日ドリンクが1杯無料になる"Welcomeドリンク"サービスです。',
+  description: 'さいたま市内のお店で使える便利でお得なサービス「たまのみ」。対象の飲食店で毎日ドリンクが1杯無料になる"Welcomeドリンク"サービスです。',
   icons: {
     icon: [
       { url: '/favicon.png', type: 'image/png' },


### PR DESCRIPTION
## 対応内容
[Issue：[SEO] TOP（/）と LP（/lp）で meta description を分離する](https://github.com/HV-development/tamanomi-web/issues/265)

### 必須: metadata.description の文言整理

- /（TOP） … src/app/layout.tsx の description を以下に合わせる。
毎日一軒ごとにドリンク一杯が無料に！さいたま市の飲食店で使えるちょっとお得な"Welcomeドリンク"サービスたまのみをご利用ください。

- /lp 配下（LP） … src/app/lp/layout.tsx の description を以下に合わせる。
さいたま市内のお店で使える便利でお得なサービス「たまのみ」。対象の飲食店で毎日ドリンクが1杯無料になる"Welcomeドリンク"サービスです。

## 確認結果
**TOPのdescription**
<img width="1919" height="230" alt="スクリーンショット 2026-05-14 13 34 53" src="https://github.com/user-attachments/assets/070618a0-feda-4882-b6e4-3f839ebe7054" />



**LPのdescription**
<img width="1914" height="225" alt="スクリーンショット 2026-05-14 13 34 33" src="https://github.com/user-attachments/assets/2ce57485-33a4-429c-aabf-30bd727783af" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk SEO text-only change limited to `metadata.description` values; no runtime logic or data flow is affected.
> 
> **Overview**
> Updates `metadata.description` copy on the TOP page (`src/app/layout.tsx`) and the LP layout (`src/app/lp/layout.tsx`), differentiating the two descriptions for SEO and adjusting the wording accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ea94b6fc51d0afb486d45b1e34ca646f1d312b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->