### PR TITLE
125-168 ポイントが付与された文言をコメントアウト

### DIFF
--- a/frontend/src/components/molecules/PlanChangeForm.tsx
+++ b/frontend/src/components/molecules/PlanChangeForm.tsx
@@ -224,9 +224,10 @@ export function PlanChangeForm({ currentPlan, onPlanChange, onCancel, isLoading 
       
       // モーダル用のメッセージを作成
       const pointsMessage = typeof data.pointsGranted === 'number' && data.pointsGranted > 0
-        ? `${data.pointsGranted}ポイントを付与しました！` 
-        : 'ポイントが付与されました！'
-      setModalMessage(`さいたま市みんなのアプリとの連携が完了しました。\n\n${pointsMessage}\n\nお得なプランが表示されます。`)
+        ? `\n\n${data.pointsGranted}ポイントを付与しました！`
+        // : 'ポイントが付与されました！'
+        : ''
+      setModalMessage(`さいたま市みんなのアプリとの連携が完了しました。${pointsMessage}\n\nお得なプランが表示されます。`)
       
       // モーダルを表示
       setShowSuccessModal(true)

--- a/frontend/src/components/organisms/PlanChangeForm.tsx
+++ b/frontend/src/components/organisms/PlanChangeForm.tsx
@@ -224,9 +224,10 @@ export function PlanChangeForm({ currentPlan, onPlanChange, onCancel, isLoading 
       
       // モーダル用のメッセージを作成
       const pointsMessage = typeof data.pointsGranted === 'number' && data.pointsGranted > 0
-        ? `${data.pointsGranted}ポイントを付与しました！` 
-        : 'ポイントが付与されました！'
-      setModalMessage(`さいたま市みんなのアプリとの連携が完了しました。\n\n${pointsMessage}\n\nお得なプランが表示されます。`)
+        ? `\n\n${data.pointsGranted}ポイントを付与しました！`
+        // : 'ポイントが付与されました！'
+        : ''
+      setModalMessage(`さいたま市みんなのアプリとの連携が完了しました。${pointsMessage}\n\nお得なプランが表示されます。`)
       
       // モーダルを表示
       setShowSuccessModal(true)

--- a/frontend/src/components/organisms/PlanRegistrationForm.tsx
+++ b/frontend/src/components/organisms/PlanRegistrationForm.tsx
@@ -147,9 +147,10 @@ export function PlanRegistrationForm({
       
       // モーダル用のメッセージを作成
       const pointsMessage = typeof data.pointsGranted === 'number' && data.pointsGranted > 0
-        ? `${data.pointsGranted}ポイントを付与しました！` 
-        : 'ポイントが付与されました！'
-      setModalMessage(`さいたま市みんなのアプリとの連携が完了しました。\n\n${pointsMessage}\n\nお得なプランが表示されます。`)
+        ? `\n\n${data.pointsGranted}ポイントを付与しました！`
+        // : 'ポイントが付与されました！'
+        : ''
+      setModalMessage(`さいたま市みんなのアプリとの連携が完了しました。${pointsMessage}\n\nお得なプランが表示されます。`)
       
       // 入力したIDを一時保存（連携完了後に設定するため）
       const linkedId = saitamaAppId


### PR DESCRIPTION
## 課題

[125-168](https://andai-dev.backlog.com/view/125-168) 令和８年５月末時点で、現行の１００ポイント還元終了


## 対応内容
`ポイントが付与されました！`を表示しないように修正しました。
表示内容を下記になるようにしました。

```
さいたま市みんなのアプリとの連携が完了しました。

お得なプランが表示されます。
```

tamanomi-apiにて、さいたまアプリID連携して新規登録を行っての
ポイント付与をしないように処理をコメントアウトするため。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI copy change limited to success-modal messaging for Saitama app linking; no business logic or data flow changes beyond string formatting.
> 
> **Overview**
> Updates the Saitama app linking success modals in `PlanChangeForm` (molecules/organisms) and `PlanRegistrationForm` to **stop showing the generic** `ポイントが付与されました！` message when no point amount is returned.
> 
> The modal now only includes a points line when `pointsGranted > 0`, otherwise it shows just the link-complete message followed by "お得なプランが表示されます。" (with adjusted newlines/formatting).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b08893f78361a7e8da8cd6dba798f298d975bede. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->