### PR TITLE
125-170 　HPとユーザーサイトのバナー削除

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
-    "@hv-development/schemas": "1.125.0",
+    "@hv-development/schemas": "1.136.0",
     "@radix-ui/react-accordion": "1.2.2",
     "@radix-ui/react-alert-dialog": "1.1.4",
     "@radix-ui/react-aspect-ratio": "1.1.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -13,8 +13,8 @@ dependencies:
     specifier: ^3.10.0
     version: 3.10.0(react-hook-form@7.68.0)
   '@hv-development/schemas':
-    specifier: 1.125.0
-    version: 1.125.0
+    specifier: 1.136.0
+    version: 1.136.0
   '@radix-ui/react-accordion':
     specifier: 1.2.2
     version: 1.2.2(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1)
@@ -579,8 +579,8 @@ packages:
     deprecated: Use @eslint/object-schema instead
     dev: true
 
-  /@hv-development/schemas@1.125.0:
-    resolution: {integrity: sha512-BpfYWVpoZvYlnyBo+e7/JCTbQyrb2+cA0GwBF6ukE9OaHJkeCn7r+hZ0vwKzA/rtmc6zaS2EWqz6fd4rIvzpbg==, tarball: https://npm.pkg.github.com/download/@hv-development/schemas/1.125.0/8c6f01863ebe942d9754e13eb2458688f7f5cbb3}
+  /@hv-development/schemas@1.136.0:
+    resolution: {integrity: sha512-6Pkxz04RakaxDxqOk7v3vZ51HyaMCs3Og5H8yxZakI6TY2ToAeGsN/RT/nocr3oXwDJtElx/rzu/9Ubl4kQVGg==, tarball: https://npm.pkg.github.com/download/@hv-development/schemas/1.136.0/4a1a952090be5f6ed1a77e8edfe4b3829ea85ef0}
     engines: {node: 22.x}
     dependencies:
       zod: 3.25.76

--- a/frontend/src/app/lp/page.tsx
+++ b/frontend/src/app/lp/page.tsx
@@ -12,11 +12,12 @@ const bannerItems = [
     linkUrl: 'https://www.tamanomi.com/lp/merchant',
     alt: '掲載店募集'
   },
-  {
-    imageUrl: '/lp/images/saitama-app-benefits-lp.webp',
-    linkUrl: 'https://www.home.saitama-tsunagu.com/',
-    alt: 'さいたま市みんなのアプリ（ユーザー特典）'
-  },
+  // 2026/5/31 キャンペーン終了に伴い非表示
+  // {
+  //   imageUrl: '/lp/images/saitama-app-benefits-lp.webp',
+  //   linkUrl: 'https://www.home.saitama-tsunagu.com/',
+  //   alt: 'さいたま市みんなのアプリ（ユーザー特典）'
+  // },
   {
     imageUrl: '/lp/images/instagram-official-lp.png',
     linkUrl: 'https://www.instagram.com/tamanomi.saitama?igsh=dTdnb2gxNGFnOWs=',
@@ -2160,4 +2161,3 @@ export default function LPPage() {
     </div>
   )
 }
-

--- a/frontend/src/components/organisms/BannerCarousel.tsx
+++ b/frontend/src/components/organisms/BannerCarousel.tsx
@@ -30,7 +30,7 @@ const banners: BannerItem[] = [
   //   alt: "さいたま市みんなのアプリ（ユーザー特典）"
   // },
   {
-    id: "banner-2",
+    id: "banner-3",
     imageUrl: "/instagram-official-user.png",
     linkUrl: "https://www.instagram.com/tamanomi.saitama?igsh=dTdnb2gxNGFnOWs=",
     alt: "公式 Instagram たまのみ部がゆく"

--- a/frontend/src/components/organisms/BannerCarousel.tsx
+++ b/frontend/src/components/organisms/BannerCarousel.tsx
@@ -22,14 +22,15 @@ const banners: BannerItem[] = [
     linkUrl: "https://www.tamanomi.com/lp/merchant",
     alt: "掲載店募集"
   },
+  // 2026/5/31 キャンペーン終了に伴い非表示
+  // {
+  //   id: "banner-2",
+  //   imageUrl: "/saitama-app-benefits-user.png",
+  //   linkUrl: "https://www.home.saitama-tsunagu.com/",
+  //   alt: "さいたま市みんなのアプリ（ユーザー特典）"
+  // },
   {
     id: "banner-2",
-    imageUrl: "/saitama-app-benefits-user.png",
-    linkUrl: "https://www.home.saitama-tsunagu.com/",
-    alt: "さいたま市みんなのアプリ（ユーザー特典）"
-  },
-  {
-    id: "banner-3",
     imageUrl: "/instagram-official-user.png",
     linkUrl: "https://www.instagram.com/tamanomi.saitama?igsh=dTdnb2gxNGFnOWs=",
     alt: "公式 Instagram たまのみ部がゆく"

--- a/frontend/src/components/organisms/EmailRegistrationForm.tsx
+++ b/frontend/src/components/organisms/EmailRegistrationForm.tsx
@@ -9,7 +9,7 @@ import {
   TamanomiUserRegistrationRequestSchema,
   type TamanomiUserRegistrationRequest,
 } from "@hv-development/schemas"
-import { z, ZodError } from "zod"
+import { z } from "zod"
 
 const tamanomiEmailOnlyFallbackSchema = z.object({
   email: z.string().email("有効なメールアドレスを入力してください"),
@@ -52,39 +52,35 @@ export function EmailRegistrationForm({
   const validateField = (fieldName: keyof TamanomiUserRegistrationRequest, value: string) => {
     const shape = preRegisterFormSchema.shape[fieldName as keyof typeof preRegisterFormSchema.shape]
     if (!shape) return
-    try {
-      shape.parse(value)
+    const result = shape.safeParse(value)
+    if (result.success) {
       setErrors((prev) => {
         const next = { ...prev }
         delete next[fieldName]
         return next
       })
-    } catch (error) {
-      if (error instanceof ZodError) {
-        const msg = error.issues[0]?.message || "入力エラーです"
-        setErrors((prev) => ({ ...prev, [fieldName]: msg }))
-      }
+    } else {
+      const msg = result.error.issues[0]?.message || "入力エラーです"
+      setErrors((prev) => ({ ...prev, [fieldName]: msg }))
     }
   }
 
   const validateForm = (): boolean => {
-    try {
-      preRegisterFormSchema.parse(formData)
+    const result = preRegisterFormSchema.safeParse(formData)
+    if (result.success) {
       setErrors({})
       return true
-    } catch (error) {
-      if (error instanceof ZodError) {
-        const newErrors: Partial<Record<keyof TamanomiUserRegistrationRequest, string>> = {}
-        for (const issue of error.issues) {
-          const fieldName = issue.path[0] as keyof TamanomiUserRegistrationRequest | undefined
-          if (fieldName === "email" || fieldName === "campaignCode" || fieldName === "referrerUserId") {
-            newErrors[fieldName] = issue.message
-          }
-        }
-        setErrors(newErrors)
-      }
-      return false
     }
+
+    const newErrors: Partial<Record<keyof TamanomiUserRegistrationRequest, string>> = {}
+    for (const issue of result.error.issues) {
+      const fieldName = issue.path[0] as keyof TamanomiUserRegistrationRequest | undefined
+      if (fieldName === "email" || fieldName === "campaignCode" || fieldName === "referrerUserId") {
+        newErrors[fieldName] = issue.message
+      }
+    }
+    setErrors(newErrors)
+    return false
   }
 
   const handleEmailChange = (value: string) => {
@@ -114,7 +110,7 @@ export function EmailRegistrationForm({
   }
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-6">
+    <form onSubmit={handleSubmit} noValidate className="space-y-6">
       <div className="text-center mb-6">
         <h3 className="text-lg font-bold text-gray-900 mb-3">メールアドレス認証</h3>
         <div className="text-gray-600 space-y-2">

--- a/frontend/src/components/organisms/RegisterForm.tsx
+++ b/frontend/src/components/organisms/RegisterForm.tsx
@@ -461,9 +461,12 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({
           onBlur={() => handleFieldBlur("saitamaAppId")}
           error={errors.saitamaAppId || undefined}
         />
-        <p className="mt-1 text-sm text-gray-500">
-          さいたま市みんなのアプリユーザー特典をご利用の方は、アプリのユーザーIDをコピーして貼り付けてください
-        </p>
+        {/*
+          2026/5/31 キャンペーン終了に伴い非表示
+          <p className="mt-1 text-sm text-gray-500">
+            さいたま市みんなのアプリユーザー特典をご利用の方は、アプリのユーザーIDをコピーして貼り付けてください
+          </p>
+        */}
       </div>
 
       {/* パスワード */}


### PR DESCRIPTION
## 修正内容


### バナー削除
- frontend/src/app/lp/page.tsx
- frontend/src/components/organisms/BannerCarousel.tsx

### 『さいたま市みんなのアプリユーザー特典をご利用の方は、アプリのユーザーIDをコピーして貼り付けてください』文言削除
- frontend/src/components/organisms/RegisterForm.tsx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> 主に表示・コピーの非表示と依存バージョン更新、登録フォームの検証実装の軽微な変更で、認証や決済などクリティカル領域への影響は限定的です。
> 
> **Overview**
> **さいたま市みんなのアプリ**のユーザー特典キャンペーン終了（2026/5/31）に合わせ、LP（`lp/page.tsx`）とユーザー画面の **`BannerCarousel`** から該当バナーをコメントアウトして非表示にし、**`RegisterForm`** の特典案内文言も同様に非表示にしています。
> 
> あわせて **`@hv-development/schemas`** を `1.125.0` から **`1.136.0`** に更新し、**`EmailRegistrationForm`** では Zod 検証を `safeParse` に寄せ、ブラウザのネイティブ検証と競合しないようフォームに **`noValidate`** を付与しています。
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a16f580550fd88bb74cec9e429501028ba130187. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->