### PR TITLE
ポイント付与の停止とキャンペーンバナーの廃止

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
-    "@hv-development/schemas": "1.136.0",
+    "@hv-development/schemas": "1.137.0",
     "@radix-ui/react-accordion": "1.2.2",
     "@radix-ui/react-alert-dialog": "1.1.4",
     "@radix-ui/react-aspect-ratio": "1.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
-    "@hv-development/schemas": "1.125.0",
+    "@hv-development/schemas": "1.136.0",
     "@radix-ui/react-accordion": "1.2.2",
     "@radix-ui/react-alert-dialog": "1.1.4",
     "@radix-ui/react-aspect-ratio": "1.1.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -13,8 +13,8 @@ dependencies:
     specifier: ^3.10.0
     version: 3.10.0(react-hook-form@7.68.0)
   '@hv-development/schemas':
-    specifier: 1.136.0
-    version: 1.136.0
+    specifier: 1.137.0
+    version: 1.137.0
   '@radix-ui/react-accordion':
     specifier: 1.2.2
     version: 1.2.2(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1)
@@ -579,8 +579,8 @@ packages:
     deprecated: Use @eslint/object-schema instead
     dev: true
 
-  /@hv-development/schemas@1.136.0:
-    resolution: {integrity: sha512-6Pkxz04RakaxDxqOk7v3vZ51HyaMCs3Og5H8yxZakI6TY2ToAeGsN/RT/nocr3oXwDJtElx/rzu/9Ubl4kQVGg==, tarball: https://npm.pkg.github.com/download/@hv-development/schemas/1.136.0/4a1a952090be5f6ed1a77e8edfe4b3829ea85ef0}
+  /@hv-development/schemas@1.137.0:
+    resolution: {integrity: sha512-p+IKxhKADvL9mesW/cyMPeDsYFuLGJ7quJV7//XTeutVcoX5599xZw1WQf3h5Hv/CqoAm6qwKw+jb1k5uIredg==, tarball: https://npm.pkg.github.com/download/@hv-development/schemas/1.137.0/e8de6e295287bce3f736406e992924fcf65e32a6}
     engines: {node: 22.x}
     dependencies:
       zod: 3.25.76

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -13,8 +13,8 @@ dependencies:
     specifier: ^3.10.0
     version: 3.10.0(react-hook-form@7.68.0)
   '@hv-development/schemas':
-    specifier: 1.125.0
-    version: 1.125.0
+    specifier: 1.136.0
+    version: 1.136.0
   '@radix-ui/react-accordion':
     specifier: 1.2.2
     version: 1.2.2(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1)
@@ -579,8 +579,8 @@ packages:
     deprecated: Use @eslint/object-schema instead
     dev: true
 
-  /@hv-development/schemas@1.125.0:
-    resolution: {integrity: sha512-BpfYWVpoZvYlnyBo+e7/JCTbQyrb2+cA0GwBF6ukE9OaHJkeCn7r+hZ0vwKzA/rtmc6zaS2EWqz6fd4rIvzpbg==, tarball: https://npm.pkg.github.com/download/@hv-development/schemas/1.125.0/8c6f01863ebe942d9754e13eb2458688f7f5cbb3}
+  /@hv-development/schemas@1.136.0:
+    resolution: {integrity: sha512-6Pkxz04RakaxDxqOk7v3vZ51HyaMCs3Og5H8yxZakI6TY2ToAeGsN/RT/nocr3oXwDJtElx/rzu/9Ubl4kQVGg==, tarball: https://npm.pkg.github.com/download/@hv-development/schemas/1.136.0/4a1a952090be5f6ed1a77e8edfe4b3829ea85ef0}
     engines: {node: 22.x}
     dependencies:
       zod: 3.25.76

--- a/frontend/src/app/lp/page.tsx
+++ b/frontend/src/app/lp/page.tsx
@@ -12,11 +12,12 @@ const bannerItems = [
     linkUrl: 'https://www.tamanomi.com/lp/merchant',
     alt: '掲載店募集'
   },
-  {
-    imageUrl: '/lp/images/saitama-app-benefits-lp.webp',
-    linkUrl: 'https://www.home.saitama-tsunagu.com/',
-    alt: 'さいたま市みんなのアプリ（ユーザー特典）'
-  },
+  // 2026/5/31 キャンペーン終了に伴い非表示
+  // {
+  //   imageUrl: '/lp/images/saitama-app-benefits-lp.webp',
+  //   linkUrl: 'https://www.home.saitama-tsunagu.com/',
+  //   alt: 'さいたま市みんなのアプリ（ユーザー特典）'
+  // },
   {
     imageUrl: '/lp/images/instagram-official-lp.png',
     linkUrl: 'https://www.instagram.com/tamanomi.saitama?igsh=dTdnb2gxNGFnOWs=',
@@ -2160,4 +2161,3 @@ export default function LPPage() {
     </div>
   )
 }
-

--- a/frontend/src/components/molecules/PlanChangeForm.tsx
+++ b/frontend/src/components/molecules/PlanChangeForm.tsx
@@ -224,9 +224,10 @@ export function PlanChangeForm({ currentPlan, onPlanChange, onCancel, isLoading 
       
       // モーダル用のメッセージを作成
       const pointsMessage = typeof data.pointsGranted === 'number' && data.pointsGranted > 0
-        ? `${data.pointsGranted}ポイントを付与しました！` 
-        : 'ポイントが付与されました！'
-      setModalMessage(`さいたま市みんなのアプリとの連携が完了しました。\n\n${pointsMessage}\n\nお得なプランが表示されます。`)
+        ? `\n\n${data.pointsGranted}ポイントを付与しました！`
+        // : 'ポイントが付与されました！'
+        : ''
+      setModalMessage(`さいたま市みんなのアプリとの連携が完了しました。${pointsMessage}\n\nお得なプランが表示されます。`)
       
       // モーダルを表示
       setShowSuccessModal(true)

--- a/frontend/src/components/organisms/BannerCarousel.tsx
+++ b/frontend/src/components/organisms/BannerCarousel.tsx
@@ -30,7 +30,7 @@ const banners: BannerItem[] = [
   //   alt: "さいたま市みんなのアプリ（ユーザー特典）"
   // },
   {
-    id: "banner-2",
+    id: "banner-3",
     imageUrl: "/instagram-official-user.png",
     linkUrl: "https://www.instagram.com/tamanomi.saitama?igsh=dTdnb2gxNGFnOWs=",
     alt: "公式 Instagram たまのみ部がゆく"

--- a/frontend/src/components/organisms/BannerCarousel.tsx
+++ b/frontend/src/components/organisms/BannerCarousel.tsx
@@ -22,14 +22,15 @@ const banners: BannerItem[] = [
     linkUrl: "https://www.tamanomi.com/lp/merchant",
     alt: "掲載店募集"
   },
+  // 2026/5/31 キャンペーン終了に伴い非表示
+  // {
+  //   id: "banner-2",
+  //   imageUrl: "/saitama-app-benefits-user.png",
+  //   linkUrl: "https://www.home.saitama-tsunagu.com/",
+  //   alt: "さいたま市みんなのアプリ（ユーザー特典）"
+  // },
   {
     id: "banner-2",
-    imageUrl: "/saitama-app-benefits-user.png",
-    linkUrl: "https://www.home.saitama-tsunagu.com/",
-    alt: "さいたま市みんなのアプリ（ユーザー特典）"
-  },
-  {
-    id: "banner-3",
     imageUrl: "/instagram-official-user.png",
     linkUrl: "https://www.instagram.com/tamanomi.saitama?igsh=dTdnb2gxNGFnOWs=",
     alt: "公式 Instagram たまのみ部がゆく"

--- a/frontend/src/components/organisms/EmailRegistrationForm.tsx
+++ b/frontend/src/components/organisms/EmailRegistrationForm.tsx
@@ -9,7 +9,7 @@ import {
   TamanomiUserRegistrationRequestSchema,
   type TamanomiUserRegistrationRequest,
 } from "@hv-development/schemas"
-import { z, ZodError } from "zod"
+import { z } from "zod"
 
 const tamanomiEmailOnlyFallbackSchema = z.object({
   email: z.string().email("有効なメールアドレスを入力してください"),
@@ -52,39 +52,35 @@ export function EmailRegistrationForm({
   const validateField = (fieldName: keyof TamanomiUserRegistrationRequest, value: string) => {
     const shape = preRegisterFormSchema.shape[fieldName as keyof typeof preRegisterFormSchema.shape]
     if (!shape) return
-    try {
-      shape.parse(value)
+    const result = shape.safeParse(value)
+    if (result.success) {
       setErrors((prev) => {
         const next = { ...prev }
         delete next[fieldName]
         return next
       })
-    } catch (error) {
-      if (error instanceof ZodError) {
-        const msg = error.issues[0]?.message || "入力エラーです"
-        setErrors((prev) => ({ ...prev, [fieldName]: msg }))
-      }
+    } else {
+      const msg = result.error.issues[0]?.message || "入力エラーです"
+      setErrors((prev) => ({ ...prev, [fieldName]: msg }))
     }
   }
 
   const validateForm = (): boolean => {
-    try {
-      preRegisterFormSchema.parse(formData)
+    const result = preRegisterFormSchema.safeParse(formData)
+    if (result.success) {
       setErrors({})
       return true
-    } catch (error) {
-      if (error instanceof ZodError) {
-        const newErrors: Partial<Record<keyof TamanomiUserRegistrationRequest, string>> = {}
-        for (const issue of error.issues) {
-          const fieldName = issue.path[0] as keyof TamanomiUserRegistrationRequest | undefined
-          if (fieldName === "email" || fieldName === "campaignCode" || fieldName === "referrerUserId") {
-            newErrors[fieldName] = issue.message
-          }
-        }
-        setErrors(newErrors)
-      }
-      return false
     }
+
+    const newErrors: Partial<Record<keyof TamanomiUserRegistrationRequest, string>> = {}
+    for (const issue of result.error.issues) {
+      const fieldName = issue.path[0] as keyof TamanomiUserRegistrationRequest | undefined
+      if (fieldName === "email" || fieldName === "campaignCode" || fieldName === "referrerUserId") {
+        newErrors[fieldName] = issue.message
+      }
+    }
+    setErrors(newErrors)
+    return false
   }
 
   const handleEmailChange = (value: string) => {
@@ -114,7 +110,7 @@ export function EmailRegistrationForm({
   }
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-6">
+    <form onSubmit={handleSubmit} noValidate className="space-y-6">
       <div className="text-center mb-6">
         <h3 className="text-lg font-bold text-gray-900 mb-3">メールアドレス認証</h3>
         <div className="text-gray-600 space-y-2">

--- a/frontend/src/components/organisms/PlanChangeForm.tsx
+++ b/frontend/src/components/organisms/PlanChangeForm.tsx
@@ -224,9 +224,10 @@ export function PlanChangeForm({ currentPlan, onPlanChange, onCancel, isLoading 
       
       // モーダル用のメッセージを作成
       const pointsMessage = typeof data.pointsGranted === 'number' && data.pointsGranted > 0
-        ? `${data.pointsGranted}ポイントを付与しました！` 
-        : 'ポイントが付与されました！'
-      setModalMessage(`さいたま市みんなのアプリとの連携が完了しました。\n\n${pointsMessage}\n\nお得なプランが表示されます。`)
+        ? `\n\n${data.pointsGranted}ポイントを付与しました！`
+        // : 'ポイントが付与されました！'
+        : ''
+      setModalMessage(`さいたま市みんなのアプリとの連携が完了しました。${pointsMessage}\n\nお得なプランが表示されます。`)
       
       // モーダルを表示
       setShowSuccessModal(true)

--- a/frontend/src/components/organisms/PlanRegistrationForm.tsx
+++ b/frontend/src/components/organisms/PlanRegistrationForm.tsx
@@ -147,9 +147,10 @@ export function PlanRegistrationForm({
       
       // モーダル用のメッセージを作成
       const pointsMessage = typeof data.pointsGranted === 'number' && data.pointsGranted > 0
-        ? `${data.pointsGranted}ポイントを付与しました！` 
-        : 'ポイントが付与されました！'
-      setModalMessage(`さいたま市みんなのアプリとの連携が完了しました。\n\n${pointsMessage}\n\nお得なプランが表示されます。`)
+        ? `\n\n${data.pointsGranted}ポイントを付与しました！`
+        // : 'ポイントが付与されました！'
+        : ''
+      setModalMessage(`さいたま市みんなのアプリとの連携が完了しました。${pointsMessage}\n\nお得なプランが表示されます。`)
       
       // 入力したIDを一時保存（連携完了後に設定するため）
       const linkedId = saitamaAppId

--- a/frontend/src/components/organisms/RegisterForm.tsx
+++ b/frontend/src/components/organisms/RegisterForm.tsx
@@ -461,9 +461,12 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({
           onBlur={() => handleFieldBlur("saitamaAppId")}
           error={errors.saitamaAppId || undefined}
         />
-        <p className="mt-1 text-sm text-gray-500">
-          さいたま市みんなのアプリユーザー特典をご利用の方は、アプリのユーザーIDをコピーして貼り付けてください
-        </p>
+        {/*
+          2026/5/31 キャンペーン終了に伴い非表示
+          <p className="mt-1 text-sm text-gray-500">
+            さいたま市みんなのアプリユーザー特典をご利用の方は、アプリのユーザーIDをコピーして貼り付けてください
+          </p>
+        */}
       </div>
 
       {/* パスワード */}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> 主に表示・コピーと依存バージョン更新で、認証や決済ロジックは触っていません。連携フロー自体は残るため、バックエンドがまだポイントを返す場合は他画面（登録確認など）との表示差にだけ注意が必要です。
> 
> **Overview**
> **さいたま市みんなのアプリ**のユーザー特典キャンペーン終了（2026/5/31）に合わせ、LP・ユーザー画面の**特典バナーをコメントアウト**し、掲載店・Instagram のみ表示するよう変更しています。
> 
> さいたまアプリ連携成功時のモーダルは、`pointsGranted` が正のときだけポイント付与文言を出し、それ以外の「ポイントが付与されました」フォールバックをやめています（`PlanChangeForm` / `PlanRegistrationForm` の molecules・organisms 両方）。新規登録フォームの特典説明テキストも非表示にしています。
> 
> `@hv-development/schemas` を **1.125.0 → 1.137.0** に上げ、`EmailRegistrationForm` は Zod の `safeParse` と `noValidate` でメール事前登録のバリデーションを整理しています。
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bebf31a331f6492292d4e8a2f2c86eca6c9117c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->