### PR TITLE
fix(auth): Neon起動待ち(503)時にログアウトせず再試行

### DIFF
--- a/frontend/src/lib/auth-fetch.ts
+++ b/frontend/src/lib/auth-fetch.ts
@@ -6,6 +6,23 @@ import { createNoCacheResponse } from '@/lib/response-utils'
 import { setTokenCookies, isSecureRequest, type TokenPair } from '@/lib/token-cookie'
 import type { HeaderOptions } from '@/lib/header-utils'
 
+const TRANSIENT_STATUS = 503
+const TRANSIENT_BACKOFFS_MS = [500, 1000, 2000]
+
+/**
+ * 503（DB起動待ち等の一時的エラー）の場合のみ短いバックオフで再試行する。
+ * ログアウト判定（401/403）には影響しない。
+ */
+async function fetchWithTransientRetry(doFetch: () => Promise<Response>): Promise<Response> {
+  let response = await doFetch()
+  for (const delay of TRANSIENT_BACKOFFS_MS) {
+    if (response.status !== TRANSIENT_STATUS) break
+    await new Promise((resolve) => setTimeout(resolve, delay))
+    response = await doFetch()
+  }
+  return response
+}
+
 export interface AuthFetchResult {
   response: NextResponse
   /** リフレッシュが実行されて成功したかどうか */
@@ -26,13 +43,15 @@ export async function authenticatedFetch(
   url: string,
   options: RequestInit & { headerOptions?: HeaderOptions } = {}
 ): Promise<AuthFetchResult> {
-  const response = await secureFetchWithCommonHeaders(request, url, {
-    ...options,
-    headerOptions: {
-      requireAuth: true,
-      ...options.headerOptions,
-    },
-  })
+  const response = await fetchWithTransientRetry(() =>
+    secureFetchWithCommonHeaders(request, url, {
+      ...options,
+      headerOptions: {
+        requireAuth: true,
+        ...options.headerOptions,
+      },
+    })
+  )
 
   if (response.status !== 401 && response.status !== 403) {
     const data = await response.json()
@@ -57,18 +76,22 @@ export async function authenticatedFetch(
   }
 
   const refreshUrl = buildApiUrl('/refresh')
-  const refreshResponse = await secureFetchWithCommonHeaders(request, refreshUrl, {
-    method: 'POST',
-    headerOptions: { requireAuth: false },
-    body: JSON.stringify({ refreshToken }),
-  })
+  const refreshResponse = await fetchWithTransientRetry(() =>
+    secureFetchWithCommonHeaders(request, refreshUrl, {
+      method: 'POST',
+      headerOptions: { requireAuth: false },
+      body: JSON.stringify({ refreshToken }),
+    })
+  )
 
   if (!refreshResponse.ok) {
+    const status = refreshResponse.status === 503 ? 503 : 401
+    const error =
+      status === 503
+        ? 'サーバーが混み合っています。しばらくしてから再試行してください。'
+        : '認証トークンが無効です。再度ログインしてください。'
     return {
-      response: createNoCacheResponse(
-        { error: '認証トークンが無効です。再度ログインしてください。' },
-        { status: 401 }
-      ),
+      response: createNoCacheResponse({ error }, { status }),
       refreshed: false,
     }
   }


### PR DESCRIPTION
## 背景
本番DB(Neon)のスリープ起動待ちで、API側が一時的エラー時に **503 + `Retry-After`** を返すようになった（関連: tamanomi-api PR #336）。本PRはクライアント側で **503をログアウト扱いせず短いバックオフで再試行**する。

## 対応
`frontend/src/lib/auth-fetch.ts`:
- ヘルパ `fetchWithTransientRetry`（503のときのみ 500/1000/2000ms で最大3回再試行）を追加
- 初回リクエストと `/refresh` 呼び出しを同ヘルパでラップ
- `/refresh` が 503 の場合は 401(ログアウト)ではなく 503 を返す。**本物の 401/403 のみログアウト**

## 検証
4リポジトリ横断でコードレビュー実施（admin系の `firstResponse.ok` 早期return・成功パス・トークン更新フローが不変であることを確認）。`auth-fetch.ts` の型エラーなし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes server-side auth and token refresh error handling; 401/403 logout behavior is preserved but transient failures now surface differently to clients.
> 
> **Overview**
> Neon DB wake-up and other **503** responses from the API no longer force users through the logout path on the Next.js BFF.
> 
> `auth-fetch.ts` adds **`fetchWithTransientRetry`**, which re-issues the same fetch up to three times (500ms / 1s / 2s backoff) **only when the status is 503**. The initial authenticated backend call and the **`/refresh`** call both use this helper.
> 
> If **`/refresh`** still fails with **503** after retries, the route returns **503** with a “server busy, try again” message instead of mapping it to **401** and the “invalid token, log in again” copy. **401/403** handling and the post-refresh retry path are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 472fc79d67f1ab45d849ff72bc3a3352b2a7f134. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->