### PR TITLE
退会完了時の自動ログアウト処理を追加

### DIFF
--- a/frontend/src/app/api/coupons/[id]/use/route.ts
+++ b/frontend/src/app/api/coupons/[id]/use/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server'
 import { buildApiUrl } from '@/lib/api-config'
-import { secureFetchWithCommonHeaders } from '@/lib/fetch-utils'
+import { authenticatedFetch } from '@/lib/auth-fetch'
 import { createNoCacheResponse } from '@/lib/response-utils'
 
 export const dynamic = 'force-dynamic'
@@ -23,33 +23,15 @@ export async function POST(
 
     const fullUrl = buildApiUrl(`/coupons/${id}/use`)
 
-    const response = await secureFetchWithCommonHeaders(request, fullUrl, {
+    const { response } = await authenticatedFetch(request, fullUrl, {
       method: 'POST',
       headerOptions: {
-        requireAuth: true, // 認証が必要
+        requireAuth: true,
       },
       body: JSON.stringify({ shopId }),
     })
 
-    // 認証エラーの場合は401を返す
-    if (response.status === 401) {
-      return createNoCacheResponse(
-        { error: '認証が必要です' },
-        { status: 401 }
-      )
-    }
-
-    const data = await response.json()
-
-    if (!response.ok) {
-      console.error('❌ [coupons/[id]/use] Backend API error:', data)
-      return createNoCacheResponse(
-        { error: data.message || data.error?.message || 'クーポンの使用に失敗しました' },
-        { status: response.status }
-      )
-    }
-    
-    return createNoCacheResponse(data)
+    return response
 
   } catch (error) {
     console.error('❌ [coupons/[id]/use] Route error:', error)

--- a/frontend/src/app/api/user/me/route.ts
+++ b/frontend/src/app/api/user/me/route.ts
@@ -13,12 +13,6 @@ export async function GET(request: NextRequest) {
       method: 'GET',
     })
 
-    const cloned = response.clone()
-    try {
-      const body = await cloned.json()
-      console.log('🔍 [user/me] accountStatus:', body.accountStatus, 'keys:', Object.keys(body).join(','))
-    } catch (e) { console.log('🔍 [user/me] clone error:', e) }
-
     return response
   } catch (error) {
     console.error('❌ [user/me] Route error:', error)

--- a/frontend/src/hooks/useCouponHandlers.ts
+++ b/frontend/src/hooks/useCouponHandlers.ts
@@ -125,6 +125,13 @@ export const useCouponHandlers = (
             })
 
             if (!response.ok) {
+                if (response.status === 401) {
+                    await auth.logout()
+                    alert('退会処理が完了したため、ログアウトしました')
+                    navigation.navigateToView("home")
+                    return
+                }
+
                 let errorMessage = 'クーポンの使用に失敗しました'
                 try {
                     const error = await response.json()
@@ -149,7 +156,7 @@ export const useCouponHandlers = (
             console.error('クーポン使用エラー:', error)
             alert(error instanceof Error ? error.message : 'クーポンの使用中にエラーが発生しました')
         }
-    }, [navigation, dispatch, state.selectedCoupon, state.selectedStore])
+    }, [auth, navigation, dispatch, state.selectedCoupon, state.selectedStore])
 
     const handleCouponListClose = useCallback(() => {
         couponFetchingStoreId = null

--- a/frontend/src/hooks/useCouponHandlers.ts
+++ b/frontend/src/hooks/useCouponHandlers.ts
@@ -37,7 +37,9 @@ export const useCouponHandlers = (
                         cache: 'no-store',
                     })
 
-                    if (authResponse.status === 401 || authResponse.status === 403) {
+                    // 401のみログアウト対象とする（リフレッシュ失敗時はauthenticatedFetchが401に正規化する。
+                    // 403は権限系エラーの可能性があるためログアウトさせない）
+                    if (authResponse.status === 401) {
                         await auth.logout()
                         dispatch({ type: 'RESET_LOGIN_STATE' })
                         dispatch({ type: 'SET_COUPON_LIST_OPEN', payload: false })
@@ -147,7 +149,8 @@ export const useCouponHandlers = (
             })
 
             if (!response.ok) {
-                if (response.status === 401 || response.status === 403) {
+                // 401のみログアウト対象（403は権限系エラーの可能性があるため通常のエラー処理に流す）
+                if (response.status === 401) {
                     await auth.logout()
                     dispatch({ type: 'RESET_LOGIN_STATE' })
                     dispatch({ type: 'SET_SELECTED_COUPON', payload: null })

--- a/frontend/src/hooks/useCouponHandlers.ts
+++ b/frontend/src/hooks/useCouponHandlers.ts
@@ -42,7 +42,7 @@ export const useCouponHandlers = (
                         dispatch({ type: 'RESET_LOGIN_STATE' })
                         dispatch({ type: 'SET_COUPON_LIST_OPEN', payload: false })
                         dispatch({ type: 'SET_SELECTED_STORE', payload: null })
-                        alert('退会処理が完了したため、ログアウトしました')
+                        alert('ログイン状態を確認できなかったため、ログアウトしました。再度ログインしてください。')
                         navigation.navigateToView("home")
                         return
                     }
@@ -147,9 +147,12 @@ export const useCouponHandlers = (
             })
 
             if (!response.ok) {
-                if (response.status === 401) {
+                if (response.status === 401 || response.status === 403) {
                     await auth.logout()
-                    alert('退会処理が完了したため、ログアウトしました')
+                    dispatch({ type: 'RESET_LOGIN_STATE' })
+                    dispatch({ type: 'SET_SELECTED_COUPON', payload: null })
+                    dispatch({ type: 'SET_SELECTED_STORE', payload: null })
+                    alert('ログイン状態を確認できなかったため、ログアウトしました。再度ログインしてください。')
                     navigation.navigateToView("home")
                     return
                 }

--- a/frontend/src/hooks/useCouponHandlers.ts
+++ b/frontend/src/hooks/useCouponHandlers.ts
@@ -30,10 +30,32 @@ export const useCouponHandlers = (
             }
             couponFetchingStoreId = storeId
 
-            dispatch({ type: 'SET_SELECTED_STORE', payload: store })
-            dispatch({ type: 'SET_COUPON_LIST_OPEN', payload: true })
-
             try {
+                if (auth.isAuthenticated) {
+                    const authResponse = await fetch('/api/user/me', {
+                        credentials: 'include',
+                        cache: 'no-store',
+                    })
+
+                    if (authResponse.status === 401 || authResponse.status === 403) {
+                        await auth.logout()
+                        dispatch({ type: 'RESET_LOGIN_STATE' })
+                        dispatch({ type: 'SET_COUPON_LIST_OPEN', payload: false })
+                        dispatch({ type: 'SET_SELECTED_STORE', payload: null })
+                        alert('退会処理が完了したため、ログアウトしました')
+                        navigation.navigateToView("home")
+                        return
+                    }
+
+                    if (!authResponse.ok) {
+                        alert('ログイン状態を確認できませんでした。時間をおいて再度お試しください。')
+                        return
+                    }
+                }
+
+                dispatch({ type: 'SET_SELECTED_STORE', payload: store })
+                dispatch({ type: 'SET_COUPON_LIST_OPEN', payload: true })
+
                 const url = `/api/coupons?shopId=${storeId}&status=approved&isPublic=true&limit=100`
 
                 const response = await fetch(url, {
@@ -90,7 +112,7 @@ export const useCouponHandlers = (
                 couponFetchingStoreId = null
             }
         }
-    }, [state.stores, dispatch])
+    }, [auth, navigation, state.stores, dispatch])
 
     const handleUseCoupon = useCallback((couponId: string) => {
         if (!auth.isAuthenticated) {

--- a/frontend/src/hooks/useNavigationHandlers.ts
+++ b/frontend/src/hooks/useNavigationHandlers.ts
@@ -54,7 +54,9 @@ export const useNavigationHandlers = (
                         cache: 'no-store',
                     })
 
-                    if (response.status === 401 || response.status === 403) {
+                    // 401のみログアウト対象とする（リフレッシュ失敗時はauthenticatedFetchが401に正規化する。
+                    // 403は権限系エラーの可能性があるためログアウトさせない）
+                    if (response.status === 401) {
                         await auth.logout()
                         dispatch({ type: 'RESET_LOGIN_STATE' })
                         navigation.navigateToView("login")

--- a/frontend/src/hooks/useNavigationHandlers.ts
+++ b/frontend/src/hooks/useNavigationHandlers.ts
@@ -42,12 +42,35 @@ export const useNavigationHandlers = (
         }
     }, [filters, dispatch])
 
-    const handleTabChange = useCallback((tab: string) => {
+    const handleTabChange = useCallback(async (tab: string) => {
         if (tab === "mypage") {
             if (!auth.isAuthenticated) {
                 dispatch({ type: 'RESET_LOGIN_STATE' })
                 navigation.navigateToView("login")
             } else {
+                try {
+                    const response = await fetch('/api/user/me', {
+                        credentials: 'include',
+                        cache: 'no-store',
+                    })
+
+                    if (response.status === 401 || response.status === 403) {
+                        await auth.logout()
+                        dispatch({ type: 'RESET_LOGIN_STATE' })
+                        navigation.navigateToView("login")
+                        return
+                    }
+
+                    if (!response.ok) {
+                        alert('ログイン状態を確認できませんでした。時間をおいて再度お試しください。')
+                        return
+                    }
+                } catch (error) {
+                    console.error('ログイン状態の確認に失敗しました:', error)
+                    alert('ログイン状態を確認できませんでした。通信環境をご確認ください。')
+                    return
+                }
+
                 navigation.navigateToView("mypage", tab)
                 navigation.navigateToMyPage("main")
             }
@@ -67,7 +90,7 @@ export const useNavigationHandlers = (
             }
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [auth.isAuthenticated, navigation, router])
+    }, [auth, dispatch, navigation, router])
 
     const handleShowStoreOnHome = useCallback(() => {
         navigation.navigateToView("home", "home")

--- a/frontend/src/lib/auth-fetch.ts
+++ b/frontend/src/lib/auth-fetch.ts
@@ -3,7 +3,7 @@ import { buildApiUrl } from '@/lib/api-config'
 import { getRefreshToken } from '@/lib/auth-header'
 import { secureFetchWithCommonHeaders } from '@/lib/fetch-utils'
 import { createNoCacheResponse } from '@/lib/response-utils'
-import { setTokenCookies, isSecureRequest, type TokenPair } from '@/lib/token-cookie'
+import { clearTokenCookies, setTokenCookies, isSecureRequest, type TokenPair } from '@/lib/token-cookie'
 import type { HeaderOptions } from '@/lib/header-utils'
 
 const TRANSIENT_STATUS = 503
@@ -66,11 +66,13 @@ export async function authenticatedFetch(
 
   const refreshToken = getRefreshToken(request)
   if (!refreshToken) {
+    const nextResponse = createNoCacheResponse(
+      { error: '認証が必要です' },
+      { status: 401 }
+    )
+    clearTokenCookies(nextResponse, isSecureRequest(request))
     return {
-      response: createNoCacheResponse(
-        { error: '認証が必要です' },
-        { status: 401 }
-      ),
+      response: nextResponse,
       refreshed: false,
     }
   }
@@ -90,8 +92,12 @@ export async function authenticatedFetch(
       status === 503
         ? 'サーバーが混み合っています。しばらくしてから再試行してください。'
         : '認証トークンが無効です。再度ログインしてください。'
+    const nextResponse = createNoCacheResponse({ error }, { status })
+    if (status === 401) {
+      clearTokenCookies(nextResponse, isSecureRequest(request))
+    }
     return {
-      response: createNoCacheResponse({ error }, { status }),
+      response: nextResponse,
       refreshed: false,
     }
   }


### PR DESCRIPTION
## 概要

退会猶予期間が満了したユーザーを、次回のAPI通信時にログアウトさせる処理を追加しました。

## 修正内容

- 認証エラー後にトークン更新ができなかった場合、認証Cookieを削除
- クーポン使用APIを共通の認証・トークン更新処理経由に変更
- クーポン使用時に`401`が返った場合、画面上のログイン状態も解除
- 退会完了を通知してホーム画面へ遷移
- 退会完了後にクーポン使用履歴が登録されることを防止

## 動作

1. 退会満了後のユーザーがクーポンを使用する
2. APIから`401`が返る
3. リフレッシュトークンによる更新を試行する
4. 更新に失敗した場合、アクセストークンとリフレッシュトークンのCookieを削除する
5. 画面上のユーザー情報やプラン情報を初期化してログアウトする

## 補足

バッチ実行時にブラウザを直接操作することはできないため、画面を開いたまま何も操作していない場合は即時ログアウトされません。

バッチ実行後、ユーザーが次にAPI通信を行ったタイミングでログアウトされます。


<img width="904" height="1714" alt="スクリーンショット 2026-06-11 13 05 54" src="https://github.com/user-attachments/assets/a8b821fd-f48e-4bf7-84c5-65c3fbe83479" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> 認証・リフレッシュ・クーポン使用の経路を変更しており、401/403の扱いや退会後の利用防止に影響するが、スコープはフロントのAPIルートとハンドラに限定されている。
> 
> **Overview**
> **退会満了などでセッションが無効になったユーザー**を、次のAPI利用時にサーバー側でCookieを消し、クライアントでもログアウト状態に揃える変更です。
> 
> `authenticatedFetch` は、リフレッシュトークンが無い／更新に失敗して **401** になるときに **認証Cookieを削除**するようになりました。クーポン使用API（`coupons/[id]/use`）は `secureFetchWithCommonHeaders` 直叩きから **`authenticatedFetch` 経由**に切り替え、ルート側の重複した401・エラー整形をやめてそのまま返す形に整理しています。
> 
> クライアントでは、**クーポン一覧を開く前**・**マイページタブ**・**クーポン確定使用**のタイミングで `/api/user/me` または使用APIを叩き、**401のみ** `logout`・`RESET_LOGIN_STATE`・ホーム／ログインへ遷移（403は権限エラー想定でログアウトしない）します。一覧表示はセッション確認が通ってからストア選択とモーダルを開く順序に変更しています。
> 
> `/api/user/me` ルートのデバッグ用 `console.log` は削除されています。
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba6c5e3021ea25341a6b048f35352b59c01ff946. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->