### PR TITLE
メンテナンスページの案内文を更新

### DIFF
--- a/frontend/src/app/maintenance/page.tsx
+++ b/frontend/src/app/maintenance/page.tsx
@@ -29,29 +29,19 @@ export default function MaintenancePage() {
           />
         </div>
         
-        {/* サービス説明 */}
-        <div 
-          className="opacity-0 animate-fade-in mb-8"
-          style={{ animationDelay: '0.5s' }}
-        >
-          <p className="text-base md:text-lg text-[#007D4F]/80 leading-relaxed">
-            たまのみは さいたま市内の飲食店で<br />
-            毎日1軒1杯無料で ドリンクを飲める<br />
-            クーポンサービスです
-          </p>
-        </div>
-        
         {/* メッセージ */}
         <div 
           className="opacity-0 animate-fade-in"
-          style={{ animationDelay: '0.8s' }}
+          style={{ animationDelay: '0.5s' }}
         >
-          <p className="text-sm md:text-base text-[#007D4F]/80 mb-2">
-            ユーザー新規登録・利用開始は
-          </p>
-          <h1 className="text-xl md:text-3xl font-bold text-[#007D4F] mb-4 tracking-wide">
-            令和8年1月20日（火）スタート！
+          <h1 className="text-2xl md:text-3xl font-medium text-[#007D4F] mb-4 tracking-wide">
+            ただいまメンテナンス中です
           </h1>
+
+          <p className="text-base md:text-lg text-[#007D4F]/70 mt-6 leading-relaxed">
+            ご不便をおかけして申し訳ございません。<br />
+            しばらくお待ちください。
+          </p>
           
           {/* 装飾的なライン */}
           <div className="flex items-center justify-center gap-4 mt-8">
@@ -64,16 +54,16 @@ export default function MaintenancePage() {
         {/* サブテキスト */}
         <p 
           className="mt-8 text-sm text-[#007D4F]/60 opacity-0 animate-fade-in"
-          style={{ animationDelay: '1.1s' }}
+          style={{ animationDelay: '0.8s' }}
         >
-          Coming Soon
+          Under Maintenance
         </p>
       </div>
       
       {/* フッター */}
       <footer 
         className="absolute bottom-8 text-xs text-[#007D4F]/40 opacity-0 animate-fade-in"
-        style={{ animationDelay: '1.3s' }}
+        style={{ animationDelay: '1s' }}
       >
         © {new Date().getFullYear()} たまのみ
       </footer>
@@ -108,4 +98,3 @@ export default function MaintenancePage() {
     </main>
   )
 }
-


### PR DESCRIPTION
## 概要

たまのみWebのメンテナンスページに表示される案内文を更新しました。

## 変更内容

- サービス開始日の案内を削除
- `Coming Soon` を削除
- 以下のメンテナンス案内へ変更
 ```
ただいまメンテナンス中です
ご不便をおかけして申し訳ございません。
しばらくお待ちください。
Under Maintenance
```


https://github.com/user-attachments/assets/65e26936-9a4c-4dc8-89d5-dbdfbb49fe23




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static marketing copy on the maintenance page only; no auth, API, or routing logic changes.
> 
> **Overview**
> The maintenance page at `/maintenance` (shown when `MAINTENANCE_MODE` is enabled) no longer uses **coming-soon** copy and instead shows a standard maintenance message.
> 
> **Removed:** the service description block (さいたま市内の飲食店クーポン説明), the launch date headline (令和8年1月20日スタート), and the “Coming Soon” subtext.
> 
> **Added:** heading **「ただいまメンテナンス中です」**, apology/wait copy in Japanese, and **“Under Maintenance”** as the English subtext. Fade-in animation delays were tightened slightly after dropping one content section.
> 
> Layout, branding, and styling are unchanged; this is copy-only on `maintenance/page.tsx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 436ea2d35f1ac5babdf1c2152bc75bfc57d74131. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->