### PR TITLE
fix(auth): 503再試行の堅牢化（レビュー指摘1-5対応）

### DIFF
--- a/frontend/src/lib/auth-fetch.ts
+++ b/frontend/src/lib/auth-fetch.ts
@@ -8,13 +8,24 @@ import type { HeaderOptions } from '@/lib/header-utils'
 
 const TRANSIENT_STATUS = 503
 const TRANSIENT_BACKOFFS_MS = [500, 1000, 2000]
+const IDEMPOTENT_METHODS = new Set(['GET', 'HEAD', 'OPTIONS'])
+
+/** GET/HEAD/OPTIONS のみ再送安全とみなす（fetchの既定メソッドはGET） */
+function isIdempotentMethod(method?: string): boolean {
+  return IDEMPOTENT_METHODS.has((method ?? 'GET').toUpperCase())
+}
 
 /**
  * 503（DB起動待ち等の一時的エラー）の場合のみ短いバックオフで再試行する。
- * ログアウト判定（401/403）には影響しない。
+ * - retry=false（非冪等なPOST等）の場合は再送せず、副作用の二重実行を防ぐ。
+ * - ログアウト判定（401/403）には影響しない。
  */
-async function fetchWithTransientRetry(doFetch: () => Promise<Response>): Promise<Response> {
+async function fetchWithTransientRetry(
+  doFetch: () => Promise<Response>,
+  { retry = true }: { retry?: boolean } = {}
+): Promise<Response> {
   let response = await doFetch()
+  if (!retry) return response
   for (const delay of TRANSIENT_BACKOFFS_MS) {
     if (response.status !== TRANSIENT_STATUS) break
     await new Promise((resolve) => setTimeout(resolve, delay))
@@ -43,18 +54,20 @@ export async function authenticatedFetch(
   url: string,
   options: RequestInit & { headerOptions?: HeaderOptions } = {}
 ): Promise<AuthFetchResult> {
-  const response = await fetchWithTransientRetry(() =>
-    secureFetchWithCommonHeaders(request, url, {
-      ...options,
-      headerOptions: {
-        requireAuth: true,
-        ...options.headerOptions,
-      },
-    })
+  const response = await fetchWithTransientRetry(
+    () =>
+      secureFetchWithCommonHeaders(request, url, {
+        ...options,
+        headerOptions: {
+          requireAuth: true,
+          ...options.headerOptions,
+        },
+      }),
+    { retry: isIdempotentMethod(options.method) }
   )
 
   if (response.status !== 401 && response.status !== 403) {
-    const data = await response.json()
+    const data = await response.json().catch(() => ({}))
     return {
       response: createNoCacheResponse(
         response.ok ? data : { error: data.message || data.error?.message || 'リクエストに失敗しました' },
@@ -78,13 +91,13 @@ export async function authenticatedFetch(
   }
 
   const refreshUrl = buildApiUrl('/refresh')
-  const refreshResponse = await fetchWithTransientRetry(() =>
-    secureFetchWithCommonHeaders(request, refreshUrl, {
-      method: 'POST',
-      headerOptions: { requireAuth: false },
-      body: JSON.stringify({ refreshToken }),
-    })
-  )
+  // refresh はリフレッシュトークンを消費するPOSTのため503でも再送しない
+  // （消費済みトークンの再送による誤ログアウトを防ぐ）。503時は下で503を返す。
+  const refreshResponse = await secureFetchWithCommonHeaders(request, refreshUrl, {
+    method: 'POST',
+    headerOptions: { requireAuth: false },
+    body: JSON.stringify({ refreshToken }),
+  })
 
   if (!refreshResponse.ok) {
     const status = refreshResponse.status === 503 ? 503 : 401
@@ -117,7 +130,7 @@ export async function authenticatedFetch(
     },
   })
 
-  const retryData = await retryResponse.json()
+  const retryData = await retryResponse.json().catch(() => ({}))
 
   if (!retryResponse.ok) {
     return {


### PR DESCRIPTION
## 概要
コードレビューで検出した、503再試行処理（Neon DB起動待ち対応）の不具合・リスク5件を是正します。対象: `frontend/src/lib/auth-fetch.ts`。

## 背景
`feature/neon-wake-retry`（develop マージ済み）の503再試行に対するレビューで以下を検出。

## 修正内容
- **finding 1,2**: 503本文が非JSON（Railway/プロキシの503ページ等）のとき `response.json()` が例外を投げ500落ちしていたのを `.catch(() => ({}))` でガード。
- **finding 3**: 503再試行を冪等メソッド（GET/HEAD/OPTIONS）のみに限定し、POST等の副作用ありリクエストの二重実行を防止。
- **finding 4**: refresh（リフレッシュトークンを消費するPOST）を503再試行対象から除外。消費済みトークン再送による誤ログアウトを防止（503時は従来どおり「混み合っています」を返却）。
- **finding 5**: refresh再試行を外したことでバックオフの二重積み上げを解消（最大 約7秒→約3.5秒）。

## 確認
- `tsc --noEmit`: auth-fetch.ts に型エラーなし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sit on the auth and retry path for all API routes using `authenticatedFetch`; behavior shifts for POST on 503 and refresh, but the intent is to reduce duplicate writes and mistaken logouts.
> 
> **Overview**
> **503 transient retry** in `auth-fetch.ts` is tightened so it is less likely to break auth flows or duplicate side effects.
> 
> `fetchWithTransientRetry` now accepts a **`retry` flag** and skips backoff when `retry` is false. The initial authenticated backend call only enables 503 retries for **GET, HEAD, and OPTIONS**; **POST and other non-idempotent methods** no longer get automatic 503 replays, avoiding double execution of mutating API calls.
> 
> **Token refresh** is a single POST with **no 503 retry**, so a consumed refresh token is not sent again (which could force logout). A 503 on refresh still surfaces the existing “server busy” message.
> 
> **JSON parsing** on error paths uses **`.catch(() => ({}))`** so non-JSON 503 bodies (e.g. proxy HTML) do not throw and turn into 500s.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f6061161d7c83315b80288c4a352425a536a1d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->