### PR TITLE
paused状態のユーザーはクーポン使用不可 / プラン登録・変更不可にする

### DIFF
--- a/frontend/src/components/molecules/CouponConfirmationPage.tsx
+++ b/frontend/src/components/molecules/CouponConfirmationPage.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image"
 import React, { useState } from 'react'
+import { Info } from "lucide-react"
 import type { Coupon } from '@/types/coupon'
 import { getDefaultCouponImage } from "@/utils/coupon-image"
 
@@ -10,12 +11,16 @@ interface CouponConfirmationPageProps {
   onConfirm: () => void
   onCancel: () => void
   currentUserRank?: string | null
+  isPaused?: boolean
+  onChangePayment?: () => void
 }
 
 export default function CouponConfirmationPage({
   coupon,
   onConfirm,
   onCancel,
+  isPaused = false,
+  onChangePayment,
 }: CouponConfirmationPageProps) {
   // 全ての背景色をブロンズ・非会員色に統一
   const backgroundColorClass = "bg-gradient-to-br from-green-50 to-green-100"
@@ -24,10 +29,12 @@ export default function CouponConfirmationPage({
   if (!coupon) return null
 
   const handleShowToStaff = () => {
+    if (isPaused) return
     setIsRotated(true)
   }
 
   const handleUse = () => {
+    if (isPaused) return
     onConfirm()
   }
 
@@ -95,47 +102,77 @@ export default function CouponConfirmationPage({
       {/* ユーザー向け利用ボタン */}
       <div className="bg-white p-4 border-t border-gray-200">
         <div className="w-full max-w-xs mx-auto">
-          <div className="space-y-3">
-            {!isRotated ? (
-              <>
-                <p className="text-sm text-gray-700 text-center mb-2">
-                  店員の方に画面をお見せください
+          {isPaused ? (
+            <div className="space-y-3">
+              <div className="flex items-start gap-2 p-3 bg-amber-50 border border-amber-200 rounded-xl">
+                <Info className="w-5 h-5 text-amber-600 flex-shrink-0 mt-0.5" />
+                <p className="text-sm text-gray-700 leading-relaxed">
+                  ご登録のお支払いカードで決済ができなかったため、クーポンをご利用いただけません。
                 </p>
-                {coupon.drinkType === 'alcohol' && (
-                  <p className="text-red-600 font-medium text-sm text-center mb-2">
-                    ※20歳未満の方はアルコールは飲めません
+              </div>
+              <button
+                onClick={onChangePayment}
+                className="w-full bg-green-600 hover:bg-green-700 text-white py-3 px-4 rounded-xl font-bold text-base transition-colors shadow-md hover:shadow-lg"
+              >
+                支払い方法を変更する
+              </button>
+              <button
+                disabled
+                aria-disabled="true"
+                className="w-full bg-gray-300 text-gray-500 py-4 px-4 rounded-xl font-bold text-lg cursor-not-allowed"
+              >
+                利用する
+              </button>
+              <button
+                onClick={onCancel}
+                className="w-full bg-gray-100 hover:bg-gray-200 text-gray-700 py-3 px-4 rounded-xl font-medium text-base transition-colors border border-gray-300"
+              >
+                キャンセル
+              </button>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {!isRotated ? (
+                <>
+                  <p className="text-sm text-gray-700 text-center mb-2">
+                    店員の方に画面をお見せください
                   </p>
-                )}
-                <button
-                  onClick={handleShowToStaff}
-                  className="w-full bg-green-600 hover:bg-green-700 text-white py-4 px-4 rounded-xl font-bold text-lg transition-colors shadow-md hover:shadow-lg"
-                >
-                  店員に見せる
-                </button>
-                <button
-                  onClick={onCancel}
-                  className="w-full bg-gray-100 hover:bg-gray-200 text-gray-700 py-3 px-4 rounded-xl font-medium text-base transition-colors border border-gray-300"
-                >
-                  キャンセル
-                </button>
-              </>
-            ) : (
-              <>
-                <button
-                  onClick={handleUse}
-                  className="w-full bg-green-600 hover:bg-green-700 text-white py-4 px-4 rounded-xl font-bold text-lg transition-colors shadow-md hover:shadow-lg"
-                >
-                  利用する
-                </button>
-                <button
-                  onClick={onCancel}
-                  className="w-full bg-gray-100 hover:bg-gray-200 text-gray-700 py-3 px-4 rounded-xl font-medium text-base transition-colors border border-gray-300"
-                >
-                  キャンセル
-                </button>
-              </>
-            )}
-          </div>
+                  {coupon.drinkType === 'alcohol' && (
+                    <p className="text-red-600 font-medium text-sm text-center mb-2">
+                      ※20歳未満の方はアルコールは飲めません
+                    </p>
+                  )}
+                  <button
+                    onClick={handleShowToStaff}
+                    className="w-full bg-green-600 hover:bg-green-700 text-white py-4 px-4 rounded-xl font-bold text-lg transition-colors shadow-md hover:shadow-lg"
+                  >
+                    店員に見せる
+                  </button>
+                  <button
+                    onClick={onCancel}
+                    className="w-full bg-gray-100 hover:bg-gray-200 text-gray-700 py-3 px-4 rounded-xl font-medium text-base transition-colors border border-gray-300"
+                  >
+                    キャンセル
+                  </button>
+                </>
+              ) : (
+                <>
+                  <button
+                    onClick={handleUse}
+                    className="w-full bg-green-600 hover:bg-green-700 text-white py-4 px-4 rounded-xl font-bold text-lg transition-colors shadow-md hover:shadow-lg"
+                  >
+                    利用する
+                  </button>
+                  <button
+                    onClick={onCancel}
+                    className="w-full bg-gray-100 hover:bg-gray-200 text-gray-700 py-3 px-4 rounded-xl font-medium text-base transition-colors border border-gray-300"
+                  >
+                    キャンセル
+                  </button>
+                </>
+              )}
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/components/molecules/HistoryPopup.tsx
+++ b/frontend/src/components/molecules/HistoryPopup.tsx
@@ -12,9 +12,11 @@ interface HistoryPopupProps {
   onFavoriteToggle: (storeId: string) => void
   onCouponsClick: (storeId: string) => void
   onStoreClick: (store: Store) => void
+  /** 支払い一時停止中で「今すぐクーポンGET」を無効化するか */
+  isCouponDisabled?: boolean
 }
 
-export function HistoryPopup({ isOpen, stores, onClose, onFavoriteToggle, onCouponsClick, onStoreClick }: HistoryPopupProps) {
+export function HistoryPopup({ isOpen, stores, onClose, onFavoriteToggle, onCouponsClick, onStoreClick, isCouponDisabled = false }: HistoryPopupProps) {
   // モーダルが開いている間、背後のスクロールを無効にする
   useEffect(() => {
     if (isOpen) {
@@ -67,6 +69,7 @@ export function HistoryPopup({ isOpen, stores, onClose, onFavoriteToggle, onCoup
               actionsLayout="vertical"
               emptyMessage="まだ閲覧履歴がありません"
               emptyEmoji="📋"
+              isCouponDisabled={isCouponDisabled}
             />
           </div>
         </div>

--- a/frontend/src/components/molecules/PausedNoticeBanner.tsx
+++ b/frontend/src/components/molecules/PausedNoticeBanner.tsx
@@ -1,0 +1,36 @@
+"use client"
+
+import { Info } from "lucide-react"
+
+interface PausedNoticeBannerProps {
+  isVisible: boolean
+  onChangePayment: () => void
+}
+
+export function PausedNoticeBanner({ isVisible, onChangePayment }: PausedNoticeBannerProps) {
+  if (!isVisible) return null
+
+  return (
+    <div className="bg-amber-50 border-b border-amber-200">
+      <div className="px-4 py-3">
+        <div className="flex items-start gap-3">
+          <Info className="w-5 h-5 text-amber-600 flex-shrink-0 mt-0.5" />
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-bold text-gray-900 leading-snug">
+              お支払い方法のご確認をお願いします
+            </p>
+            <p className="text-sm text-gray-700 leading-snug mt-1">
+              ご登録のお支払いカードで決済ができなかったため、クーポンをご利用いただけません。お支払い方法をご変更ください。
+            </p>
+            <button
+              onClick={onChangePayment}
+              className="mt-2 inline-flex items-center justify-center px-4 py-2 bg-green-600 hover:bg-green-700 text-white text-sm font-medium rounded-lg transition-colors"
+            >
+              支払い方法を変更する
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/molecules/StoreCard.tsx
+++ b/frontend/src/components/molecules/StoreCard.tsx
@@ -17,6 +17,8 @@ interface StoreCardProps {
   className?: string
   /** クーポン/店舗チェックボタンの並び方（お気に入りは縦、それ以外は既存の横並び） */
   actionsLayout?: "horizontal" | "vertical"
+  /** 支払い一時停止中で「今すぐクーポンGET」を無効化するか */
+  isCouponDisabled?: boolean
 }
 
 export function StoreCard({
@@ -27,6 +29,7 @@ export function StoreCard({
   showDistance = false,
   className = "",
   actionsLayout = "horizontal",
+  isCouponDisabled = false,
 }: StoreCardProps) {
   const [currentImageIndex, setCurrentImageIndex] = useState(0)
   const [isImageError, setIsImageError] = useState(false)
@@ -235,10 +238,15 @@ export function StoreCard({
             onClick={(e) => {
               e.preventDefault()
               e.stopPropagation()
-              onCouponsClick(store.id)
+              if (isCouponDisabled) {
+                // 支払い一時停止中はクーポン一覧を開かず、店舗詳細を表示する
+                onStoreClick(store)
+              } else {
+                onCouponsClick(store.id)
+              }
             }}
             className="w-full aspect-[4/3] md:aspect-[16/9] rounded-lg overflow-hidden bg-white flex items-center justify-center cursor-pointer relative"
-            aria-label="店舗画像"
+            aria-label={isCouponDisabled ? "店舗詳細を表示" : "店舗画像"}
           >
             <Image
               src="/store-default.svg"
@@ -294,10 +302,16 @@ export function StoreCard({
         >
           <button
             onClick={() => onCouponsClick(store.id)}
+            disabled={isCouponDisabled}
+            aria-disabled={isCouponDisabled}
             className={
-              actionsLayout === "vertical"
-                ? "w-full flex items-center justify-center bg-green-600 hover:bg-green-700 text-white py-3 px-4 rounded-2xl transition-all duration-300 transform hover:scale-[1.02] shadow-md hover:shadow-lg font-medium"
-                : "flex-1 max-[400px]:w-full flex items-center justify-center bg-green-600 hover:bg-green-700 text-white py-3 px-4 rounded-2xl transition-all duration-300 transform hover:scale-[1.02] shadow-md hover:shadow-lg font-medium"
+              isCouponDisabled
+                ? (actionsLayout === "vertical"
+                  ? "w-full flex items-center justify-center bg-gray-300 text-gray-500 py-3 px-4 rounded-2xl font-medium cursor-not-allowed"
+                  : "flex-1 max-[400px]:w-full flex items-center justify-center bg-gray-300 text-gray-500 py-3 px-4 rounded-2xl font-medium cursor-not-allowed")
+                : (actionsLayout === "vertical"
+                  ? "w-full flex items-center justify-center bg-green-600 hover:bg-green-700 text-white py-3 px-4 rounded-2xl transition-all duration-300 transform hover:scale-[1.02] shadow-md hover:shadow-lg font-medium"
+                  : "flex-1 max-[400px]:w-full flex items-center justify-center bg-green-600 hover:bg-green-700 text-white py-3 px-4 rounded-2xl transition-all duration-300 transform hover:scale-[1.02] shadow-md hover:shadow-lg font-medium")
             }
           >
             <span>今すぐクーポンGET</span>

--- a/frontend/src/components/molecules/StoreList.tsx
+++ b/frontend/src/components/molecules/StoreList.tsx
@@ -16,6 +16,8 @@ interface StoreListProps {
   className?: string
   showEmptyMessage?: boolean
   isLoading?: boolean
+  /** 支払い一時停止中で「今すぐクーポンGET」を無効化するか */
+  isCouponDisabled?: boolean
 }
 
 export function StoreList({
@@ -30,6 +32,7 @@ export function StoreList({
   className = "",
   showEmptyMessage = true,
   isLoading = false,
+  isCouponDisabled = false,
 }: StoreListProps) {
   // ローディング中はスピナーを表示
   if (isLoading) {
@@ -66,6 +69,7 @@ export function StoreList({
           onStoreClick={onStoreClick ?? (() => { })}
           showDistance={showDistance}
           actionsLayout={actionsLayout}
+          isCouponDisabled={isCouponDisabled}
         />
       ))}
     </div>

--- a/frontend/src/components/molecules/SubscriptionPausedModal.tsx
+++ b/frontend/src/components/molecules/SubscriptionPausedModal.tsx
@@ -1,0 +1,76 @@
+"use client"
+
+import { Info, X } from "lucide-react"
+
+interface SubscriptionPausedModalProps {
+  isOpen: boolean
+  mode?: 'preCheck' | 'apiError'
+  onChangePayment: () => void
+  onClose: () => void
+}
+
+export function SubscriptionPausedModal({
+  isOpen,
+  mode = 'preCheck',
+  onChangePayment,
+  onClose,
+}: SubscriptionPausedModalProps) {
+  if (!isOpen) return null
+
+  const title = mode === 'apiError'
+    ? 'クーポンをご利用いただけませんでした'
+    : 'お支払い方法のご確認をお願いします'
+
+  const message = mode === 'apiError'
+    ? 'お支払い状況が更新されています。お手数ですが、ページを再読み込みしてご確認ください。'
+    : 'ご登録のお支払いカードで決済ができなかったため、クーポンをご利用いただけません。お支払い方法をご変更ください。'
+
+  return (
+    <>
+      {/* オーバーレイ */}
+      <div className="fixed inset-0 bg-black/30 backdrop-blur-sm z-50" onClick={onClose}></div>
+
+      {/* ポップアップ */}
+      <div className="fixed inset-x-4 top-1/2 -translate-y-1/2 bg-white rounded-3xl shadow-2xl z-50 max-w-md mx-auto border-2 border-amber-200">
+        <div className="p-6">
+          {/* ヘッダー */}
+          <div className="flex items-center justify-between mb-4">
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-amber-100 rounded-full">
+                <Info className="w-6 h-6 text-amber-600" />
+              </div>
+              <h3 className="text-lg font-bold text-gray-900">{title}</h3>
+            </div>
+            <button
+              onClick={onClose}
+              className="p-2 hover:bg-gray-100 rounded-full transition-colors"
+            >
+              <X className="w-5 h-5 text-gray-600" />
+            </button>
+          </div>
+
+          {/* メッセージ */}
+          <p className="text-gray-700 mb-6 leading-relaxed">
+            {message}
+          </p>
+
+          {/* ボタン */}
+          <div className="flex flex-col gap-3">
+            <button
+              onClick={onChangePayment}
+              className="w-full px-4 py-3 bg-green-600 text-white rounded-xl font-medium hover:bg-green-700 transition-colors"
+            >
+              支払い方法を変更する
+            </button>
+            <button
+              onClick={onClose}
+              className="w-full px-4 py-3 bg-gray-200 text-gray-700 rounded-xl font-medium hover:bg-gray-300 transition-colors"
+            >
+              閉じる
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/frontend/src/components/organisms/HomeContainer.tsx
+++ b/frontend/src/components/organisms/HomeContainer.tsx
@@ -24,24 +24,27 @@ interface HomeContainerProps {
   currentLocation?: { latitude: number; longitude: number } | null
   // 初期ローディング状態
   isInitialLoading?: boolean
+  /** 支払い一時停止中で「今すぐクーポンGET」を無効化するか */
+  isCouponDisabled?: boolean
 }
 
-export function HomeContainer({ 
+export function HomeContainer({
   selectedGenres: _selectedGenres, // eslint-disable-line @typescript-eslint/no-unused-vars
-  selectedEvents, 
-  selectedAreas, 
-  isNearbyFilter, 
-  isFavoritesFilter, 
-  stores, 
-  onStoreClick, 
-  onFavoriteToggle, 
-  onCouponsClick, 
-  backgroundColorClass = "bg-gradient-to-br from-green-50 to-green-100", 
-  loadMoreRef, 
-  isLoadingMore = false, 
-  bottomError = null, 
+  selectedEvents,
+  selectedAreas,
+  isNearbyFilter,
+  isFavoritesFilter,
+  stores,
+  onStoreClick,
+  onFavoriteToggle,
+  onCouponsClick,
+  backgroundColorClass = "bg-gradient-to-br from-green-50 to-green-100",
+  loadMoreRef,
+  isLoadingMore = false,
+  bottomError = null,
   currentLocation,
-  isInitialLoading = false
+  isInitialLoading = false,
+  isCouponDisabled = false,
 }: HomeContainerProps) {
   // 店舗データをフィルタリング
   const filteredStores = useMemo(() => {
@@ -130,6 +133,7 @@ export function HomeContainer({
           emptyEmoji="🔍"
           showEmptyMessage={!isInitialLoading && stores !== undefined && stores.length === 0}
           isLoading={isInitialLoading}
+          isCouponDisabled={isCouponDisabled}
         />
 
         {/* 追加ロード時のローディング表示 */}

--- a/frontend/src/components/organisms/MypageContainer.tsx
+++ b/frontend/src/components/organisms/MypageContainer.tsx
@@ -374,22 +374,29 @@ const MenuButtons = React.memo(({
   accountStatus?: string
 }) => {
   const isWithdrawing = accountStatus === 'withdrawing'
+  const isPaused = plan?.status === 'paused'
   const planMenuLabel = plan ? "プランの変更" : "プラン登録"
-  
+  const planMenuDisabled = isWithdrawing || isPaused
+  const planMenuDisplay = isWithdrawing
+    ? <span>プランの変更<br /><span className="text-xs">（退会処理済みのため利用不可）</span></span>
+    : isPaused
+      ? <span>プランの変更<br /><span className="text-xs">（お支払い一時停止中のため利用不可）</span></span>
+      : planMenuLabel
+
   return (
     <div className="space-y-3">
       {onStoreIntroduction && (
-        <MenuButton 
-          onClick={onStoreIntroduction} 
-          icon={Store} 
-          label={hasStoreIntroduction ? "店舗紹介（変更）" : "店舗紹介"} 
+        <MenuButton
+          onClick={onStoreIntroduction}
+          icon={Store}
+          label={hasStoreIntroduction ? "店舗紹介（変更）" : "店舗紹介"}
         />
       )}
       {appConfig.myPageSettings.showProfile && (
         <MenuButton onClick={onEditProfile} icon={SquarePen} label="プロフィール編集" />
       )}
       {appConfig.myPageSettings.showPlanManagement && (
-        <MenuButton onClick={onViewPlan} icon={RefreshCw} label={isWithdrawing ? <span>プランの変更<br /><span className="text-xs">（退会処理済みのため利用不可）</span></span> : planMenuLabel} disabled={isWithdrawing} />
+        <MenuButton onClick={onViewPlan} icon={RefreshCw} label={planMenuDisplay} disabled={planMenuDisabled} />
       )}
       {appConfig.myPageSettings.showPlanManagement && plan && onChangePaymentMethod && (
         <MenuButton onClick={onChangePaymentMethod} icon={Wallet} label={isWithdrawing ? <span>支払方法の変更<br /><span className="text-xs">（退会処理済みのため利用不可）</span></span> : "支払方法の変更"} disabled={isWithdrawing} />

--- a/frontend/src/components/organisms/StoreDetailPopup.tsx
+++ b/frontend/src/components/organisms/StoreDetailPopup.tsx
@@ -12,13 +12,16 @@ interface StoreDetailPopupProps {
   onClose: () => void
   onFavoriteToggle: (storeId: string) => void
   onCouponsClick: (storeId: string) => void
+  /** 支払い一時停止中で「今すぐクーポンGET」を無効化するか */
+  isCouponDisabled?: boolean
 }
 
 export function StoreDetailPopup({
   isOpen,
   store,
   onClose,
-  onCouponsClick
+  onCouponsClick,
+  isCouponDisabled = false,
 }: StoreDetailPopupProps) {
   const [currentImageIndex, setCurrentImageIndex] = useState(0)
   const [isImageError, setIsImageError] = useState(false)
@@ -384,7 +387,13 @@ export function StoreDetailPopup({
               <div className="pt-2">
                 <button
                   onClick={() => onCouponsClick(store.id)}
-                  className="w-full flex items-center justify-center bg-green-600 hover:bg-green-700 text-white py-3 px-4 rounded-xl transition-all duration-300 transform hover:scale-[1.02] shadow-md hover:shadow-lg"
+                  disabled={isCouponDisabled}
+                  aria-disabled={isCouponDisabled}
+                  className={
+                    isCouponDisabled
+                      ? "w-full flex items-center justify-center bg-gray-300 text-gray-500 py-3 px-4 rounded-xl font-medium cursor-not-allowed"
+                      : "w-full flex items-center justify-center bg-green-600 hover:bg-green-700 text-white py-3 px-4 rounded-xl transition-all duration-300 transform hover:scale-[1.02] shadow-md hover:shadow-lg"
+                  }
                 >
                   <span className="font-medium">今すぐクーポンGET</span>
                 </button>

--- a/frontend/src/components/templates/HomeLayout.tsx
+++ b/frontend/src/components/templates/HomeLayout.tsx
@@ -788,6 +788,14 @@ export function HomeLayout({ onMount }: HomeLayoutProps) {
 
     // プラン変更画面の場合
     if (myPageView === "plan-change") {
+      // paused ユーザーは直リンク・状態復元で来てもプラン変更できないため、
+      // 支払い方法変更画面へ強制リダイレクト（メニュー導線のガードに加える二重防御）
+      if (plan?.status === 'paused') {
+        if (typeof window !== 'undefined') {
+          window.location.href = '/payment-method-change'
+        }
+        return null
+      }
       if (!plan) {
         return (
           <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-green-50 to-green-100">
@@ -830,7 +838,7 @@ export function HomeLayout({ onMount }: HomeLayoutProps) {
       return (
         <PlanManagementContainer
           plan={plan}
-          onChangePlan={() => onMyPageViewChange("plan-change")}
+          onChangePlan={handlers.handleChangePlan}
           onCancelSubscription={onCancelSubscription}
           onChangePaymentMethod={onChangePaymentMethod}
           hasPaymentMethod={hasPaymentMethod}

--- a/frontend/src/components/templates/HomeLayout.tsx
+++ b/frontend/src/components/templates/HomeLayout.tsx
@@ -21,6 +21,8 @@ import { CouponListPopup } from "../molecules/CouponListPopup"
 import { CouponUsedSuccessModal } from "../molecules/CouponUsedSuccessModal"
 import { LoginRequiredModal } from "../molecules/LoginRequiredModal"
 import { PlanRequiredModal } from "../molecules/PlanRequiredModal"
+import { SubscriptionPausedModal } from "../molecules/SubscriptionPausedModal"
+import { PausedNoticeBanner } from "../molecules/PausedNoticeBanner"
 import { EmailChangeSuccessModal } from "../organisms/EmailChangeSuccessModal"
 import { StoreDetailPopup } from "@/components/organisms/StoreDetailPopup"
 import { Logo } from "../atoms/Logo"
@@ -430,6 +432,11 @@ export function HomeLayout({ onMount }: HomeLayoutProps) {
   const isPlanRequiredModalOpen = state.isPlanRequiredModalOpen
   const onPlanRequiredModalClose = handlers.handlePlanRequiredModalClose
   const onPlanRequiredModalRegister = handlers.handlePlanRequiredModalRegister
+  const isSubscriptionPausedModalOpen = state.isSubscriptionPausedModalOpen
+  const subscriptionPausedModalMode = state.subscriptionPausedModalMode
+  const onSubscriptionPausedModalClose = handlers.handleSubscriptionPausedModalClose
+  const onSubscriptionPausedModalChangePayment = handlers.handleSubscriptionPausedModalChangePayment
+  const isPlanPaused = auth.plan?.status === 'paused'
   const onProfileEditSubmit = handlers.handleProfileEditSubmit
   const onEmailChangeSubmit = handlers.handleEmailChangeSubmit
   const onPasswordChangeSubmit = handlers.handlePasswordChangeSubmit
@@ -712,6 +719,8 @@ export function HomeLayout({ onMount }: HomeLayoutProps) {
         coupon={selectedCoupon}
         onConfirm={onConfirmCoupon}
         onCancel={onCancelCoupon}
+        isPaused={isPlanPaused}
+        onChangePayment={onSubscriptionPausedModalChangePayment}
       />
     )
   }
@@ -1071,6 +1080,12 @@ export function HomeLayout({ onMount }: HomeLayoutProps) {
         }}
       />
 
+      {/* 支払い一時停止中バナー（home 最上部に常時表示） */}
+      <PausedNoticeBanner
+        isVisible={isPlanPaused}
+        onChangePayment={onSubscriptionPausedModalChangePayment}
+      />
+
       <div className="flex-1 overflow-hidden">
         <HomeContainer
           selectedGenres={selectedGenres}
@@ -1089,6 +1104,7 @@ export function HomeLayout({ onMount }: HomeLayoutProps) {
           backgroundColorClass={backgroundColorClass}
           currentLocation={state.currentLocation}
           isInitialLoading={isSearchMode ? isSearching : isInitialStoresLoading}
+          isCouponDisabled={isPlanPaused}
         />
       </div>
 
@@ -1100,6 +1116,7 @@ export function HomeLayout({ onMount }: HomeLayoutProps) {
         onFavoriteToggle={onFavoriteToggle}
         onCouponsClick={onCouponsClick}
         onStoreClick={onStoreClick}
+        isCouponDisabled={isPlanPaused}
       />
 
       {/* 閲覧履歴ポップアップ */}
@@ -1110,6 +1127,7 @@ export function HomeLayout({ onMount }: HomeLayoutProps) {
         onFavoriteToggle={onFavoriteToggle}
         onCouponsClick={onCouponsClick}
         onStoreClick={onStoreClick}
+        isCouponDisabled={isPlanPaused}
       />
 
       <StoreDetailPopup
@@ -1122,6 +1140,7 @@ export function HomeLayout({ onMount }: HomeLayoutProps) {
         }}
         onFavoriteToggle={onFavoriteToggle}
         onCouponsClick={onCouponsClick}
+        isCouponDisabled={isPlanPaused}
       />
 
       {/* クーポン関連ポップアップ */}
@@ -1166,6 +1185,14 @@ export function HomeLayout({ onMount }: HomeLayoutProps) {
         isOpen={isPlanRequiredModalOpen}
         onClose={onPlanRequiredModalClose}
         onRegisterPlan={onPlanRequiredModalRegister}
+      />
+
+      {/* 支払い一時停止中モーダル */}
+      <SubscriptionPausedModal
+        isOpen={isSubscriptionPausedModalOpen}
+        mode={subscriptionPausedModalMode}
+        onClose={onSubscriptionPausedModalClose}
+        onChangePayment={onSubscriptionPausedModalChangePayment}
       />
 
       {/* メールアドレス変更成功モーダル */}

--- a/frontend/src/hooks/useAppHandlers.ts
+++ b/frontend/src/hooks/useAppHandlers.ts
@@ -1,12 +1,13 @@
 "use client"
 
 import React from "react"
-import type { AppAction, AppState, AppHandlers } from '@hv-development/schemas'
+import type { AppState, AppHandlers } from '@hv-development/schemas'
+import type { AppActionExt } from './useAppReducer'
+import type { AppHandlersExt } from '@/types/app-context'
 import type { useAuth } from './useAuth'
 import type { useNavigation } from './useNavigation'
 import type { useFilters } from './useFilters'
 import type { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime'
-import type { CreateStoreIntroductionRequest } from '@/types/store-introduction'
 import { useAuthHandlers } from './useAuthHandlers'
 import { useWithdrawalHandlers } from './useWithdrawalHandlers'
 import { useCouponHandlers } from './useCouponHandlers'
@@ -16,13 +17,13 @@ import { useMyPageHandlers } from './useMyPageHandlers'
 import { useNavigationHandlers } from './useNavigationHandlers'
 
 export const useAppHandlers = (
-    dispatch: React.Dispatch<AppAction>,
+    dispatch: React.Dispatch<AppActionExt>,
     auth: ReturnType<typeof useAuth>,
     navigation: ReturnType<typeof useNavigation>,
     filters: ReturnType<typeof useFilters>,
     router: AppRouterInstance,
     state: AppState
-): AppHandlers => {
+): AppHandlersExt => {
 
     const authHandlers = useAuthHandlers(dispatch, auth, navigation, router, state)
     const withdrawalHandlers = useWithdrawalHandlers(dispatch, auth, navigation)
@@ -41,5 +42,5 @@ export const useAppHandlers = (
         ...planHandlers,
         ...withdrawalHandlers,
         handleProfileEditSubmit: profileHandlers.handleProfileEditSubmit as AppHandlers['handleProfileEditSubmit'],
-    } as AppHandlers & { handleEmailChangeSuccessModalClose: () => void; handleStoreIntroduction: () => void; handleStoreIntroductionSubmit: (data: CreateStoreIntroductionRequest) => Promise<void> }
+    } as AppHandlersExt
 }

--- a/frontend/src/hooks/useAppReducer.ts
+++ b/frontend/src/hooks/useAppReducer.ts
@@ -1,7 +1,22 @@
 import type { AppState, AppAction } from '@hv-development/schemas'
 
+// schemas を変更せずに paused モーダル用の state/action をローカルで拡張する
+export type SubscriptionPausedModalMode = 'preCheck' | 'apiError'
+
+export type AppStateExt = AppState & {
+    isSubscriptionPausedModalOpen: boolean
+    subscriptionPausedModalMode: SubscriptionPausedModalMode
+}
+
+export type AppActionExt =
+    | AppAction
+    | {
+        type: 'SET_SUBSCRIPTION_PAUSED_MODAL'
+        payload: { open: boolean; mode: SubscriptionPausedModalMode }
+    }
+
 // 初期状態
-export const initialState: AppState = {
+export const initialState: AppStateExt = {
     stores: [],
     notifications: [],
     isDataLoaded: true,
@@ -34,10 +49,12 @@ export const initialState: AppState = {
     isLocationLoading: false,
     locationError: null,
     isSearchPopupOpen: false,
+    isSubscriptionPausedModalOpen: false,
+    subscriptionPausedModalMode: 'preCheck',
 }
 
 // リデューサー（簡略化）
-export function appReducer(state: AppState, action: AppAction): AppState {
+export function appReducer(state: AppStateExt, action: AppActionExt): AppStateExt {
     switch (action.type) {
         case 'SET_STORES':
             return { ...state, stores: action.payload }
@@ -59,6 +76,12 @@ export function appReducer(state: AppState, action: AppAction): AppState {
             return { ...state, isLoginRequiredModalOpen: action.payload }
         case 'SET_PLAN_REQUIRED_MODAL_OPEN':
             return { ...state, isPlanRequiredModalOpen: action.payload }
+        case 'SET_SUBSCRIPTION_PAUSED_MODAL':
+            return {
+                ...state,
+                isSubscriptionPausedModalOpen: action.payload.open,
+                subscriptionPausedModalMode: action.payload.mode,
+            }
         case 'SET_STORE_DETAIL_POPUP_OPEN':
             return { ...state, isStoreDetailPopupOpen: action.payload }
         case 'SET_FAVORITES_OPEN':

--- a/frontend/src/hooks/useCouponHandlers.ts
+++ b/frontend/src/hooks/useCouponHandlers.ts
@@ -168,9 +168,9 @@ export const useCouponHandlers = (
                     errorBody = {}
                 }
 
-                // 支払いが一時停止中（バックエンドから直接 403 を受領した場合のフォールバック）
+                // 支払いが一時停止中（バックエンドから直接 409 を受領した場合のフォールバック）
                 if (
-                    response.status === 403 &&
+                    response.status === 409 &&
                     typeof errorBody.error === 'object' &&
                     errorBody.error?.code === 'SUBSCRIPTION_PAUSED'
                 ) {

--- a/frontend/src/hooks/useCouponHandlers.ts
+++ b/frontend/src/hooks/useCouponHandlers.ts
@@ -1,7 +1,8 @@
 "use client"
 
 import React, { useCallback, useRef, useEffect } from "react"
-import type { AppAction, AppState, Store } from '@hv-development/schemas'
+import type { AppState, Store } from '@hv-development/schemas'
+import type { AppActionExt } from './useAppReducer'
 import type { useAuth } from './useAuth'
 import type { useNavigation } from './useNavigation'
 import type { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime'
@@ -9,7 +10,7 @@ import type { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.
 let couponFetchingStoreId: string | null = null
 
 export const useCouponHandlers = (
-    dispatch: React.Dispatch<AppAction>,
+    dispatch: React.Dispatch<AppActionExt>,
     auth: ReturnType<typeof useAuth>,
     navigation: ReturnType<typeof useNavigation>,
     router: AppRouterInstance,
@@ -160,17 +161,37 @@ export const useCouponHandlers = (
                     return
                 }
 
-                let errorMessage = 'クーポンの使用に失敗しました'
+                let errorBody: { error?: { code?: string; message?: string } | string; message?: string } = {}
                 try {
-                    const error = await response.json()
-                    if (error.error?.message) {
-                        errorMessage = error.error.message
-                    } else if (error.message) {
-                        errorMessage = error.message
-                    } else if (error.error) {
-                        errorMessage = error.error
-                    }
+                    errorBody = await response.json()
                 } catch {
+                    errorBody = {}
+                }
+
+                // 支払いが一時停止中（バックエンドから直接 403 を受領した場合のフォールバック）
+                if (
+                    response.status === 403 &&
+                    typeof errorBody.error === 'object' &&
+                    errorBody.error?.code === 'SUBSCRIPTION_PAUSED'
+                ) {
+                    dispatch({
+                        type: 'SET_SUBSCRIPTION_PAUSED_MODAL',
+                        payload: { open: true, mode: 'apiError' },
+                    })
+                    dispatch({ type: 'SET_SELECTED_COUPON', payload: null })
+                    dispatch({ type: 'SET_SELECTED_STORE', payload: null })
+                    navigation.navigateToView("home")
+                    return
+                }
+
+                let errorMessage = 'クーポンの使用に失敗しました'
+                if (typeof errorBody.error === 'object' && errorBody.error?.message) {
+                    errorMessage = errorBody.error.message
+                } else if (errorBody.message) {
+                    errorMessage = errorBody.message
+                } else if (typeof errorBody.error === 'string') {
+                    errorMessage = errorBody.error
+                } else {
                     errorMessage = `クーポンの使用に失敗しました (HTTP ${response.status})`
                 }
                 alert(errorMessage)
@@ -244,6 +265,21 @@ export const useCouponHandlers = (
         router.push('/plan-registration')
     }, [dispatch, router])
 
+    const handleSubscriptionPausedModalClose = useCallback(() => {
+        dispatch({
+            type: 'SET_SUBSCRIPTION_PAUSED_MODAL',
+            payload: { open: false, mode: 'preCheck' },
+        })
+    }, [dispatch])
+
+    const handleSubscriptionPausedModalChangePayment = useCallback(() => {
+        dispatch({
+            type: 'SET_SUBSCRIPTION_PAUSED_MODAL',
+            payload: { open: false, mode: 'preCheck' },
+        })
+        router.push('/payment-method-change')
+    }, [dispatch, router])
+
     return {
         handleCouponsClick,
         handleUseCoupon,
@@ -259,5 +295,7 @@ export const useCouponHandlers = (
         handleLoginRequiredModalLogin,
         handlePlanRequiredModalClose,
         handlePlanRequiredModalRegister,
+        handleSubscriptionPausedModalClose,
+        handleSubscriptionPausedModalChangePayment,
     }
 }

--- a/frontend/src/hooks/useCouponHandlers.ts
+++ b/frontend/src/hooks/useCouponHandlers.ts
@@ -128,6 +128,16 @@ export const useCouponHandlers = (
             return
         }
 
+        // paused は CouponListPopup の disable では拾えない経路（状態取得前に開いていた / 途中で paused 化）
+        // への二重防御。API 側 (409 SUBSCRIPTION_PAUSED) でも止まるが、ここで先に遮断する。
+        if (auth.plan.status === 'paused') {
+            dispatch({
+                type: 'SET_SUBSCRIPTION_PAUSED_MODAL',
+                payload: { open: true, mode: 'preCheck' },
+            })
+            return
+        }
+
         const coupon = state.storeCoupons.find((c) => c.id === couponId)
         if (coupon) {
             dispatch({ type: 'SET_SELECTED_COUPON', payload: coupon })

--- a/frontend/src/hooks/usePlanHandlers.ts
+++ b/frontend/src/hooks/usePlanHandlers.ts
@@ -23,8 +23,13 @@ export const usePlanHandlers = (
     }, [navigation, router, auth])
 
     const handleChangePlan = useCallback(() => {
+        // 支払いが一時停止中の場合はプラン変更ではなく支払い方法変更に誘導
+        if (auth.plan?.status === 'paused') {
+            router.push('/payment-method-change')
+            return
+        }
         navigation.navigateToMyPage("plan-change")
-    }, [navigation])
+    }, [navigation, router, auth.plan])
 
     const handlePlanChangeSubmit = useCallback(async (planId: string, alsoChangePaymentMethod?: boolean) => {
         try {

--- a/frontend/src/hooks/usePlanRegistration.ts
+++ b/frontend/src/hooks/usePlanRegistration.ts
@@ -55,6 +55,13 @@ export function usePlanRegistration() {
     try {
       const userData = await fetchCurrentUser()
 
+      // 支払いが一時停止中のユーザーはプラン登録画面を使わせない
+      // （新規登録ではなく支払い方法変更で再開すべきため、専用画面へリダイレクト）
+      if (userData.plan?.status === 'paused') {
+        router.replace('/payment-method-change')
+        return userData
+      }
+
       if (userData.email) {
         setEmail(userData.email)
       } else {
@@ -78,7 +85,7 @@ export function usePlanRegistration() {
       setError(err instanceof Error ? err.message : 'ユーザー情報の取得中にエラーが発生しました。')
       return null
     }
-  }, [])
+  }, [router])
 
   // --- プラン一覧取得 ---
   const loadPlans = useCallback(async (explicitLinkedState?: boolean | null) => {

--- a/frontend/src/services/plan-registration.ts
+++ b/frontend/src/services/plan-registration.ts
@@ -9,6 +9,9 @@ export interface UserData {
   email?: string
   saitamaAppLinked?: boolean
   userCards?: unknown[]
+  plan?: {
+    status?: string
+  } | null
 }
 
 export interface CardRegisterResponse {

--- a/frontend/src/types/app-context.ts
+++ b/frontend/src/types/app-context.ts
@@ -1,17 +1,27 @@
-import type { AppState, AppAction, AppHandlers } from '@hv-development/schemas'
+import type { AppHandlers } from '@hv-development/schemas'
+import type { AppStateExt, AppActionExt } from '@/hooks/useAppReducer'
 import type { useAuth } from '@/hooks/useAuth'
 import type { useNavigation } from '@/hooks/useNavigation'
 import type { useFilters } from '@/hooks/useFilters'
 import type { useComputedValues } from '@/hooks/useComputedValues'
+import type { CreateStoreIntroductionRequest } from '@/types/store-introduction'
+
+export type AppHandlersExt = AppHandlers & {
+  handleEmailChangeSuccessModalClose: () => void
+  handleStoreIntroduction: () => void
+  handleStoreIntroductionSubmit: (data: CreateStoreIntroductionRequest) => Promise<void>
+  handleSubscriptionPausedModalClose: () => void
+  handleSubscriptionPausedModalChangePayment: () => void
+}
 
 /**
  * AppContext の型定義
  * ホーム画面全体の状態を管理するContext用の型
  */
 export interface AppContextType {
-  state: AppState
-  dispatch: React.Dispatch<AppAction>
-  handlers: AppHandlers
+  state: AppStateExt
+  dispatch: React.Dispatch<AppActionExt>
+  handlers: AppHandlersExt
   auth: ReturnType<typeof useAuth>
   navigation: ReturnType<typeof useNavigation>
   filters: ReturnType<typeof useFilters>


### PR DESCRIPTION
## 概要

paused（決済失敗による一時停止）状態のユーザーがクーポン使用 / プラン登録 / プラン変更を行えないように、フロントエンドの UI と画面遷移を制御します。

ユーザーには「お支払いカードで決済ができなかった」原因と「お支払い方法を変更してください」という行動を、ホーム最上部のバナーで常時案内します。

## 背景

- バックエンド `/me` API を修正し、paused 状態の UserPlan も返却するようにした
- これによりフロント側で `auth.plan?.status === 'paused'` で paused 状態を判定可能に
- 「決済失敗中なのにクーポンを使用できる」 問題を解消

## 仕様

| UserPlan.status | クーポン使用 | プラン登録・変更 | フロント UI |
|---|---|---|---|
| active | 許可 | 許可 | 通常 |
| **paused** | **拒否** | **拒否** | バナー表示 + 各ボタン disable + 画面遷移ガード |
| withdrawing | 許可 | 拒否（既存挙動を踏襲） | 通常 + withdrawing 用注釈 |

paused 検出時の主な動線:

- ホーム最上部に常時警告バナー
- 「今すぐクーポンGET」ボタン → グレーアウト disable
- マイページ「プランの変更」 → グレーアウト disable + 注釈
- `/plan-registration` 直リンク → `/payment-method-change` へ自動リダイレクト
- バナー / モーダルの「支払い方法を変更する」ボタン → `/payment-method-change` へ遷移

## 修正点

### 新規ファイル (2)

| ファイル | 役割 |
|---|---|
| `frontend/src/components/molecules/PausedNoticeBanner.tsx` | ホーム最上部に常時表示する案内バナー |
| `frontend/src/components/molecules/SubscriptionPausedModal.tsx` | API エラー時のフォールバック用モーダル |

### 編集ファイル (15)

**UI コンポーネント**

| ファイル | 変更内容 |
|---|---|
| `components/molecules/CouponConfirmationPage.tsx` | `isPaused` props 追加。paused 時に警告 UI + 「利用する」ボタン disable + 「支払い方法を変更する」ボタン表示 |
| `components/molecules/HistoryPopup.tsx` | `isCouponDisabled` props 中継 |
| `components/molecules/StoreCard.tsx` | 「今すぐクーポンGET」disable + 画像プレースホルダーは paused 時に店舗詳細を開く挙動に変更 |
| `components/molecules/StoreList.tsx` | `isCouponDisabled` props 中継 |
| `components/organisms/StoreDetailPopup.tsx` | 「今すぐクーポンGET」disable |
| `components/organisms/HomeContainer.tsx` | `isCouponDisabled` props 中継 |
| `components/organisms/MypageContainer.tsx` | 「プランの変更」を paused 時 disable + 「（お支払い一時停止中のため利用不可）」注釈付き |

**テンプレート**

| ファイル | 変更内容 |
|---|---|
| `components/templates/HomeLayout.tsx` | `PausedNoticeBanner` / `SubscriptionPausedModal` をマウント、`isPlanPaused = auth.plan?.status === 'paused'` を各 UI に伝搬 |

**フック / Service / 型**

| ファイル | 変更内容 |
|---|---|
| `hooks/useAppReducer.ts` | `@hv-development/schemas` を非変更のままローカル拡張型 `AppStateExt` / `AppActionExt` を追加。新 action `SET_SUBSCRIPTION_PAUSED_MODAL` を実装 |
| `hooks/useAppHandlers.ts` | dispatch 型と戻り値型を拡張型 `AppActionExt` / `AppHandlersExt` に揃え |
| `hooks/useCouponHandlers.ts` | クーポン使用 API が `403 SUBSCRIPTION_PAUSED` を返した時にモーダル発火 + close / changePayment ハンドラ追加 |
| `hooks/usePlanHandlers.ts` | `handleChangePlan` で paused 検出時に `/payment-method-change` へ早期リダイレクト |
| `hooks/usePlanRegistration.ts` | マウント時に paused 検出 → `/payment-method-change` へ replace。直リンク防御 |
| `services/plan-registration.ts` | `UserData` 型に `plan?: { status?: string }` を追加 |
| `types/app-context.ts` | `AppHandlersExt` 型を新規定義。`AppContextType` を拡張型に揃え |

### 文言

- バナー / モーダルタイトル: 「お支払い方法のご確認をお願いします」
- バナー / モーダル本文: 「ご登録のお支払いカードで決済ができなかったため、クーポンをご利用いただけません。お支払い方法をご変更ください。」
- アクションボタン: 「支払い方法を変更する」



## 関連

- バックエンド側 PR: `tamanomi-api` の同名ブランチ `feature-coupon-paused-restriction`
- 横展開先: `nomoca-kagawa-web` の同名ブランチ（同パターンで実装済）