### PR TITLE
退会経路を DELETE /api/user-plans/:id に一本化

### DIFF
--- a/frontend/src/app/api/user-plans/[id]/route.ts
+++ b/frontend/src/app/api/user-plans/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server'
 import { buildApiUrl } from '@/lib/api-config'
-import { secureFetchWithCommonHeaders } from '@/lib/fetch-utils'
+import { authenticatedFetch } from '@/lib/auth-fetch'
 import { createNoCacheResponse } from '@/lib/response-utils'
 
 export const dynamic = 'force-dynamic'
@@ -16,51 +16,25 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
     const { id: userPlanId } = await params
     if (!userPlanId) {
       return createNoCacheResponse(
-        { success: false, message: 'ユーザープランIDが指定されていません' },
+        { error: 'ユーザープランIDが指定されていません' },
         { status: 400 }
       )
     }
 
     const fullUrl = buildApiUrl(`/plans/user-plans/${userPlanId}`)
 
-    const response = await secureFetchWithCommonHeaders(request, fullUrl, {
+    const { response } = await authenticatedFetch(request, fullUrl, {
       method: 'DELETE',
       headerOptions: {
-        requireAuth: true, // 認証が必要
+        requireAuth: true,
       },
     })
 
-    // 認証エラーの場合は401を返す
-    if (response.status === 401) {
-      return createNoCacheResponse(
-        { success: false, message: '認証が必要です' },
-        { status: 401 }
-      )
-    }
-
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}))
-      const message =
-        errorData.error?.message ||
-        errorData.message ||
-        'ユーザープランの解約に失敗しました'
-
-      return createNoCacheResponse(
-        { success: false, message, error: errorData },
-        { status: response.status }
-      )
-    }
-
-    const data = await response.json().catch(() => ({}))
-
-    return createNoCacheResponse(
-      { success: true, data },
-      { status: 200 }
-    )
+    return response
   } catch (error) {
     console.error('❌ [user-plans/:id] DELETE error:', error)
     return createNoCacheResponse(
-      { success: false, message: 'ユーザープランの解約中にエラーが発生しました' },
+      { error: 'ユーザープランの解約中にエラーが発生しました' },
       { status: 500 }
     )
   }

--- a/frontend/src/hooks/useWithdrawalHandlers.ts
+++ b/frontend/src/hooks/useWithdrawalHandlers.ts
@@ -42,33 +42,27 @@ export const useWithdrawalHandlers = (
             const runningId = userData.userPlan?.paygentRunningId || userData.plan?.paygentRunningId
             const userPlanId = userData.userPlan?.id
 
-            if (!runningId) {
-                if (!userPlanId) {
-                    const withdrawResponse = await fetch('/api/user/withdraw', {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({}),
-                        credentials: 'include',
-                    })
-
-                    if (!withdrawResponse.ok) {
-                        const errorData = await withdrawResponse.json().catch(() => ({}))
-                        throw new Error(errorData.error?.message || errorData.message || '退会処理に失敗しました')
-                    }
-
-                    await auth.refreshUser()
-                    navigation.navigateToMyPage("withdrawal-complete")
-                    return
+            if (!userPlanId) {
+                // データ不整合防御: Paygent 継続課金が生きているのに UserPlan が取れないケース。
+                // このまま /api/user/withdraw に落とすと Paygent 側の課金が止まらず、
+                // 退会後も課金され続ける最悪状態になるため、ユーザーに再読み込みを促す。
+                if (runningId) {
+                    throw new Error(
+                        'ユーザープラン情報を取得できませんでした。マイページを再読み込みしてから再度お試しください。'
+                    )
                 }
 
-                const deleteResponse = await fetch(`/api/user-plans/${userPlanId}`, {
-                    method: 'DELETE',
+                // Paygent 未登録 & UserPlan なし → アカウント全体の退会
+                const withdrawResponse = await fetch('/api/user/withdraw', {
+                    method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({}),
+                    credentials: 'include',
                 })
 
-                if (!deleteResponse.ok) {
-                    const errorData = await deleteResponse.json().catch(() => ({}))
-                    throw new Error(errorData.message || errorData.error?.message || '退会処理に失敗しました')
+                if (!withdrawResponse.ok) {
+                    const errorData = await withdrawResponse.json().catch(() => ({}))
+                    throw new Error(errorData.error?.message || errorData.message || '退会処理に失敗しました')
                 }
 
                 await auth.refreshUser()
@@ -76,47 +70,19 @@ export const useWithdrawalHandlers = (
                 return
             }
 
-            const nextBillingDate = userData.userPlan?.nextBillingDate || userData.plan?.nextBillingDate
-
-            if (!nextBillingDate) {
-                throw new Error('次回課金日が見つかりません')
-            }
-
-            const formatDate = (date: Date | string): string => {
-                const d = typeof date === 'string' ? new Date(date) : date
-                const year = d.getFullYear()
-                const month = String(d.getMonth() + 1).padStart(2, '0')
-                const day = String(d.getDate()).padStart(2, '0')
-                return `${year}${month}${day}`
-            }
-
-            const endScheduled = formatDate(nextBillingDate)
-
-            if (!userPlanId) {
-                throw new Error(
-                    'ユーザープラン情報を取得できませんでした。マイページを再読み込みしてから再度お試しください。'
-                )
-            }
-
-            const response = await fetch('/api/payment/update', {
-                method: 'POST',
+            // userPlan あり: バックエンド deleteUserPlan で Paygent 電文283 送信 + DB 更新
+            // paygentRunningId 有無に関わらず一本化（バックエンドが Paygent 未登録は自動スキップ）
+            // 当日退会でも P050 が発生しない（電文283 は end_scheduled パラメータなし）
+            const deleteResponse = await fetch(`/api/user-plans/${userPlanId}`, {
+                method: 'DELETE',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                    userPlanId,
-                    customerId: user.paymentCard?.paygentCustomerId,
-                    customerCardId: user.paymentCard?.paygentCustomerCardId,
-                    runningId: runningId,
-                    endScheduled: endScheduled,
-                    description: '退会処理',
-                }),
             })
 
-            if (!response.ok) {
-                const errorData = await response.json().catch(() => ({}))
-                throw new Error(errorData.error || errorData.message || '退会処理に失敗しました')
+            if (!deleteResponse.ok) {
+                const errorData = await deleteResponse.json().catch(() => ({}))
+                throw new Error(errorData.message || errorData.error?.message || '退会処理に失敗しました')
             }
 
-            await response.json()
             await auth.refreshUser()
             navigation.navigateToMyPage("withdrawal-complete")
         } catch (error) {

--- a/frontend/src/hooks/useWithdrawalHandlers.ts
+++ b/frontend/src/hooks/useWithdrawalHandlers.ts
@@ -79,8 +79,13 @@ export const useWithdrawalHandlers = (
             })
 
             if (!deleteResponse.ok) {
-                const errorData = await deleteResponse.json().catch(() => ({}))
-                throw new Error(errorData.message || errorData.error?.message || '退会処理に失敗しました')
+                const errorData: { error?: { message?: string } | string; message?: string } =
+                    await deleteResponse.json().catch(() => ({}))
+                const errorMessage =
+                    (typeof errorData.error === 'object' ? errorData.error?.message : errorData.error) ||
+                    errorData.message ||
+                    '退会処理に失敗しました'
+                throw new Error(errorMessage)
             }
 
             await auth.refreshUser()


### PR DESCRIPTION
## 概要

退会画面の API 呼び出し経路を `DELETE /api/user-plans/:id`（電文283 経路）に一本化する。
`runningId` の有無で分岐する `POST /api/payment/update`（電文281 経路）の呼び出しを削除。

## 背景

### 前提: Paygent 継続課金電文の種類

| 電文 | 用途 | 制約 |
|---|---|---|
| **電文281**（継続課金変更電文） | 継続課金情報を変更する（金額・カード・終了予定日等） | `endScheduled`（終了予定日）は「明日以降」しか指定できない |
| **電文283**（継続課金終了電文） | 継続課金を即時終了する | 日付パラメータなし |

### 現状の課題

- 当日退会で **電文281 の P050 エラー**（`終了予定日は明日以降を指定して下さい`）が発生していた
- 従来の実装は `runningId` を持つ有料契約中ユーザーで `POST /api/payment/update`（電文281 経路）を叩いており、この経路では当日退会時に Paygent が P050 を返すバグがあった
- tamanomi-api [#388](https://github.com/HV-development/tamanomi-api/pull/388) で `deleteUserPlan()` に電文283 送信対応が入るため、合わせて `DELETE /api/user-plans/:id` に一本化する

## 修正点

- `frontend/src/hooks/useWithdrawalHandlers.ts` の `handleWithdrawConfirm` を修正
  - `runningId` の有無による分岐を削除
  - `nextBillingDate` / `formatDate` / `endScheduled` の計算を削除
  - `POST /api/payment/update` の呼び出しを削除
  - `userPlanId` の有無で 2 経路（`POST /api/user/withdraw` / `DELETE /api/user-plans/:id`）に一本化
  - データ不整合防御（runningId あり × userPlanId なし の場合、Paygent 課金が止まらないリスクがあるためユーザーに再読み込みを促す throw）は維持


## リリース順序

**3リポジトリの PR をマージ・同時デプロイ**が必須。
- tamanomi-api PR:  [#388](https://github.com/HV-development/tamanomi-api/pull/388) 
- nomoca-kagawa-web PR: `feature/withdrawal-endpoint-unification`
