### PR TITLE
⚡️ fix(payment-history): 決済日の翌日ズレ修正と決済ID表示の調整

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
-    "@hv-development/schemas": "1.137.0",
+    "@hv-development/schemas": "1.138.0",
     "@radix-ui/react-accordion": "1.2.2",
     "@radix-ui/react-alert-dialog": "1.1.4",
     "@radix-ui/react-aspect-ratio": "1.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
-    "@hv-development/schemas": "1.138.0",
+    "@hv-development/schemas": "1.139.0",
     "@radix-ui/react-accordion": "1.2.2",
     "@radix-ui/react-alert-dialog": "1.1.4",
     "@radix-ui/react-aspect-ratio": "1.1.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -13,8 +13,8 @@ dependencies:
     specifier: ^3.10.0
     version: 3.10.0(react-hook-form@7.68.0)
   '@hv-development/schemas':
-    specifier: 1.137.0
-    version: 1.137.0
+    specifier: 1.138.0
+    version: 1.138.0
   '@radix-ui/react-accordion':
     specifier: 1.2.2
     version: 1.2.2(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1)
@@ -235,24 +235,24 @@ packages:
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
     engines: {node: '>=6.9.0'}
 
-  /@emnapi/core@1.10.0:
-    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+  /@emnapi/core@1.11.2:
+    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
     requiresBuild: true
     dependencies:
-      '@emnapi/wasi-threads': 1.2.1
+      '@emnapi/wasi-threads': 1.2.2
       tslib: 2.8.1
     dev: true
     optional: true
 
-  /@emnapi/runtime@1.10.0:
-    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+  /@emnapi/runtime@1.11.2:
+    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
     requiresBuild: true
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  /@emnapi/wasi-threads@1.2.1:
-    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+  /@emnapi/wasi-threads@1.2.2:
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
     requiresBuild: true
     dependencies:
       tslib: 2.8.1
@@ -579,8 +579,8 @@ packages:
     deprecated: Use @eslint/object-schema instead
     dev: true
 
-  /@hv-development/schemas@1.137.0:
-    resolution: {integrity: sha512-p+IKxhKADvL9mesW/cyMPeDsYFuLGJ7quJV7//XTeutVcoX5599xZw1WQf3h5Hv/CqoAm6qwKw+jb1k5uIredg==, tarball: https://npm.pkg.github.com/download/@hv-development/schemas/1.137.0/e8de6e295287bce3f736406e992924fcf65e32a6}
+  /@hv-development/schemas@1.138.0:
+    resolution: {integrity: sha512-naHG2BxDQ6x0eQCZzimQRGa0rjxGFMkbMflU/lceB0mXEKkPZeJv6ylDhSqOFy9REmvzdEjbuoqkrri2WYUuJg==, tarball: https://npm.pkg.github.com/download/@hv-development/schemas/1.138.0/8ce0463fe20b028607ad9fcd469cd51b79a85832}
     engines: {node: 22.x}
     dependencies:
       zod: 3.25.76
@@ -767,7 +767,7 @@ packages:
     cpu: [wasm32]
     requiresBuild: true
     dependencies:
-      '@emnapi/runtime': 1.10.0
+      '@emnapi/runtime': 1.11.2
     optional: true
 
   /@img/sharp-win32-arm64@0.34.5:
@@ -829,9 +829,9 @@ packages:
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
     requiresBuild: true
     dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.2
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@tybys/wasm-util': 0.10.3
     dev: true
     optional: true
 
@@ -2202,8 +2202,8 @@ packages:
       tslib: 2.8.1
     dev: false
 
-  /@tybys/wasm-util@0.10.2:
-    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+  /@tybys/wasm-util@0.10.3:
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
     requiresBuild: true
     dependencies:
       tslib: 2.8.1

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -13,8 +13,8 @@ dependencies:
     specifier: ^3.10.0
     version: 3.10.0(react-hook-form@7.68.0)
   '@hv-development/schemas':
-    specifier: 1.138.0
-    version: 1.138.0
+    specifier: 1.139.0
+    version: 1.139.0
   '@radix-ui/react-accordion':
     specifier: 1.2.2
     version: 1.2.2(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1)
@@ -579,8 +579,8 @@ packages:
     deprecated: Use @eslint/object-schema instead
     dev: true
 
-  /@hv-development/schemas@1.138.0:
-    resolution: {integrity: sha512-naHG2BxDQ6x0eQCZzimQRGa0rjxGFMkbMflU/lceB0mXEKkPZeJv6ylDhSqOFy9REmvzdEjbuoqkrri2WYUuJg==, tarball: https://npm.pkg.github.com/download/@hv-development/schemas/1.138.0/8ce0463fe20b028607ad9fcd469cd51b79a85832}
+  /@hv-development/schemas@1.139.0:
+    resolution: {integrity: sha512-kpUq6FE7nEu/aHn8RaUCEKSZniFesj+C46qc2ddRIAmY1vqPw+q1jtQxoyYJGSVFviSZSfdTkC9Jz1GT+1W7Sg==, tarball: https://npm.pkg.github.com/download/@hv-development/schemas/1.139.0/2d4e8e2223dba82448beeffef756d638f298dd5f}
     engines: {node: 22.x}
     dependencies:
       zod: 3.25.76

--- a/frontend/src/components/organisms/PaymentHistoryList.tsx
+++ b/frontend/src/components/organisms/PaymentHistoryList.tsx
@@ -2,8 +2,6 @@
 
 import Image from "next/image"
 import { CreditCard } from "lucide-react"
-import { format } from "date-fns"
-import { ja } from "date-fns/locale"
 import type { PaymentHistory } from "@/types/user"
 
 interface PaymentHistoryListProps {
@@ -22,8 +20,14 @@ export function PaymentHistoryList({
   // 全ての背景色をブロンズ・非会員色に統一
   const backgroundColorClass = "bg-gradient-to-br from-green-50 to-green-100"
 
-  const formatDate = (date: Date) => {
-    return format(date, "yyyy年M月d日 HH:mm", { locale: ja })
+  const formatDate = (date: Date | string) => {
+    // receivedTime はJSTの日時をそのままUTCフィールドに保持しているため、
+    // ブラウザのタイムゾーンに依存させず、UTC値のまま（＝JSTの表記のまま）描画する。
+    const d = new Date(date)
+    const year = d.getUTCFullYear()
+    const month = d.getUTCMonth() + 1
+    const day = d.getUTCDate()
+    return `${year}年${month}月${day}日`
   }
 
   const formatPaymentId = (paymentId: string) => {
@@ -75,7 +79,7 @@ export function PaymentHistoryList({
               <CreditCard className="w-8 h-8 text-green-600" />
             </div>
             <div className="text-green-700 text-lg font-medium mb-2">まだ決済履歴がありません</div>
-            <div className="text-green-600 text-sm">プランに登録すると履歴がここに表示されます</div>
+            <div className="text-green-600 text-sm">決済が完了すると履歴がここに表示されます</div>
           </div>
         </div>
       </div>
@@ -122,7 +126,7 @@ export function PaymentHistoryList({
                 {/* 決済ID */}
                 <div className="mb-4">
                   <div className="text-green-600 font-medium mb-2">決済ID</div>
-                  <div className="font-bold text-xl text-gray-900">
+                  <div className="font-bold text-base text-gray-900">
                     {formatPaymentId(item.paymentId)}
                   </div>
                 </div>

--- a/frontend/src/components/organisms/PaymentHistoryList.tsx
+++ b/frontend/src/components/organisms/PaymentHistoryList.tsx
@@ -21,9 +21,14 @@ export function PaymentHistoryList({
   const backgroundColorClass = "bg-gradient-to-br from-green-50 to-green-100"
 
   const formatDate = (date: Date | string) => {
-    // receivedTime はJSTの日時をそのままUTCフィールドに保持しているため、
-    // ブラウザのタイムゾーンに依存させず、UTC値のまま（＝JSTの表記のまま）描画する。
+    // ⚠️ デプロイ順序依存: このUTC描画が正しいのは API #392 (tamanomi-api) 適用後のみ。
+    //   - API #392 適用後: paidAt は「JSTの日時をそのままUTCフィールドに保持」した値。
+    //     → getUTC* でそのまま描画する（＝JSTの表記になる）のが正しい。
+    //   - API #392 適用前(現行): paidAt = createdAt(本物のUTC)。
+    //     この描画だと早朝(JST 9時前)の決済が前日にズレるため、必ず API #392 → 本フロント の順でデプロイすること。
     const d = new Date(date)
+    // receivedTime が null の行は paidAt が空文字 "" で返り、new Date("") が Invalid Date になるため防御する
+    if (Number.isNaN(d.getTime())) return "-"
     const year = d.getUTCFullYear()
     const month = d.getUTCMonth() + 1
     const day = d.getUTCDate()


### PR DESCRIPTION
## 変更概要
- 決済日表示を、TZ変換せず UTC フィールドの値をそのまま描画するよう変更（`date-fns` の `format`/`ja` 依存を除去）。
- 決済日は日付のみ表示に変更（時刻は不要のため削除）。
- 決済ID（UUID）が折り返していたため、フォントサイズを縮小（`text-xl` → `text-base`）。
- 決済履歴が空のときの案内文を、実態に合わせて変更。
  - 変更前: 「プランに登録すると履歴がここに表示されます」
  - 変更後: 「決済が完了すると履歴がここに表示されます」

<img width="225" height="295" alt="image" src="https://github.com/user-attachments/assets/4d6717ee-3b44-4a64-b761-494e56fc4b4c" />




## テスト
- [ ] 決済履歴で決済日が正しい JST 日付で表示される
- [ ] 決済ID が折り返さず表示される
- [ ] 決済履歴が0件のとき、または未来日の場合に新しい案内文が表示される

## 影響範囲
- 決済履歴一覧（`PaymentHistoryList`）の表示のみ。

## 備考
- `receivedTime` は絶対時刻としては「JSTの数字を UTC 保持」した値のため、今後この値を表示する箇所を追加する場合も同様に TZ 変換せず描画すること。
- 本PRは決済履歴表示の改善。バックエンド（`tamanomi-api`）・型定義（`tamanomi-schemas`）の対応は別PR。