### PR TITLE
cancelled ユーザー向け再契約誘導バナーを追加

### DIFF
--- a/frontend/src/components/molecules/PlanCancelledNoticeBanner.tsx
+++ b/frontend/src/components/molecules/PlanCancelledNoticeBanner.tsx
@@ -20,9 +20,9 @@ export function PlanCancelledNoticeBanner({ isVisible, onRegisterPlan }: PlanCan
               プランのご登録をお願いします
             </p>
             <p className="text-sm text-gray-700 leading-snug mt-1">
-              ご登録のお支払いカードで決済ができなかったため、現在ご契約中のプランがございません。
+              ご契約中のプランが終了しております。
               <br />
-              再度プランをご登録ください。
+              引き続きクーポンをご利用いただくには、再度プランをご登録ください。
             </p>
             <button
               onClick={onRegisterPlan}

--- a/frontend/src/components/molecules/PlanCancelledNoticeBanner.tsx
+++ b/frontend/src/components/molecules/PlanCancelledNoticeBanner.tsx
@@ -20,7 +20,9 @@ export function PlanCancelledNoticeBanner({ isVisible, onRegisterPlan }: PlanCan
               プランのご登録をお願いします
             </p>
             <p className="text-sm text-gray-700 leading-snug mt-1">
-              ご登録のお支払いカードで決済ができなかったため、現在ご契約中のプランがございません。引き続きクーポンをご利用いただくには、再度プランをご登録ください。
+              ご登録のお支払いカードで決済ができなかったため、現在ご契約中のプランがございません。
+              <br />
+              再度プランをご登録ください。
             </p>
             <button
               onClick={onRegisterPlan}

--- a/frontend/src/components/molecules/PlanCancelledNoticeBanner.tsx
+++ b/frontend/src/components/molecules/PlanCancelledNoticeBanner.tsx
@@ -1,0 +1,36 @@
+"use client"
+
+import { Info } from "lucide-react"
+
+interface PlanCancelledNoticeBannerProps {
+  isVisible: boolean
+  onRegisterPlan: () => void
+}
+
+export function PlanCancelledNoticeBanner({ isVisible, onRegisterPlan }: PlanCancelledNoticeBannerProps) {
+  if (!isVisible) return null
+
+  return (
+    <div className="bg-amber-50 border-b border-amber-200">
+      <div className="px-4 py-3">
+        <div className="flex items-start gap-3">
+          <Info className="w-5 h-5 text-amber-600 flex-shrink-0 mt-0.5" />
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-bold text-gray-900 leading-snug">
+              プランのご登録をお願いします
+            </p>
+            <p className="text-sm text-gray-700 leading-snug mt-1">
+              ご登録のお支払いカードで決済ができなかったため、現在ご契約中のプランがございません。引き続きクーポンをご利用いただくには、再度プランをご登録ください。
+            </p>
+            <button
+              onClick={onRegisterPlan}
+              className="mt-2 inline-flex items-center justify-center px-4 py-2 bg-green-600 hover:bg-green-700 text-white text-sm font-medium rounded-lg transition-colors"
+            >
+              プランを登録する
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/templates/HomeLayout.tsx
+++ b/frontend/src/components/templates/HomeLayout.tsx
@@ -23,6 +23,7 @@ import { LoginRequiredModal } from "../molecules/LoginRequiredModal"
 import { PlanRequiredModal } from "../molecules/PlanRequiredModal"
 import { SubscriptionPausedModal } from "../molecules/SubscriptionPausedModal"
 import { PausedNoticeBanner } from "../molecules/PausedNoticeBanner"
+import { PlanCancelledNoticeBanner } from "../molecules/PlanCancelledNoticeBanner"
 import { EmailChangeSuccessModal } from "../organisms/EmailChangeSuccessModal"
 import { StoreDetailPopup } from "@/components/organisms/StoreDetailPopup"
 import { Logo } from "../atoms/Logo"
@@ -437,6 +438,7 @@ export function HomeLayout({ onMount }: HomeLayoutProps) {
   const onSubscriptionPausedModalClose = handlers.handleSubscriptionPausedModalClose
   const onSubscriptionPausedModalChangePayment = handlers.handleSubscriptionPausedModalChangePayment
   const isPlanPaused = auth.plan?.status === 'paused'
+  const isPlanCancelled = auth.hasOnlyCancelledPlans === true
   const onProfileEditSubmit = handlers.handleProfileEditSubmit
   const onEmailChangeSubmit = handlers.handleEmailChangeSubmit
   const onPasswordChangeSubmit = handlers.handlePasswordChangeSubmit
@@ -1092,6 +1094,12 @@ export function HomeLayout({ onMount }: HomeLayoutProps) {
       <PausedNoticeBanner
         isVisible={isPlanPaused}
         onChangePayment={onSubscriptionPausedModalChangePayment}
+      />
+
+      {/* 契約プランなしバナー（決済失敗で cancelled になったユーザー向け） */}
+      <PlanCancelledNoticeBanner
+        isVisible={isPlanCancelled}
+        onRegisterPlan={onPlanRequiredModalRegister}
       />
 
       <div className="flex-1 overflow-hidden">

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -121,17 +121,11 @@ export function useAuth() {
         }
     }, [fetchUsageHistory, fetchUserMe]);
 
-    const login = (
-        userData: User,
-        planData: Plan | undefined,
-        usage: UsageHistory[],
-        payment: PaymentHistory[],
-        hasOnlyCancelledPlansValue: boolean = false,
-    ) => {
+    const login = (userData: User, planData: Plan | undefined, usage: UsageHistory[], payment: PaymentHistory[]) => {
         setIsAuthenticated(true);
         setUser(userData);
         setPlan(planData);
-        setHasOnlyCancelledPlans(hasOnlyCancelledPlansValue);
+        setHasOnlyCancelledPlans((userData as User & { hasOnlyCancelledPlans?: boolean }).hasOnlyCancelledPlans === true);
         setUsageHistory(usage);
         setPaymentHistory(payment);
     };

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -6,6 +6,7 @@ export function useAuth() {
     const [isLoading, setIsLoading] = useState(false);
     const [user, setUser] = useState<User | undefined>(undefined);
     const [plan, setPlan] = useState<Plan | undefined>(undefined);
+    const [hasOnlyCancelledPlans, setHasOnlyCancelledPlans] = useState<boolean>(false);
     const [usageHistory, setUsageHistory] = useState<UsageHistory[]>([]);
     const [paymentHistory, setPaymentHistory] = useState<PaymentHistory[]>([]);
     const hasInitialized = useRef(false);
@@ -95,12 +96,13 @@ export function useAuth() {
                 const initAuth = async () => {
                     try {
                         const result = await fetchUserMe();
-                        
+
                         if (result.data) {
-                            const userData = result.data as User & { plan?: Plan; paymentHistory?: PaymentHistory[] };
+                            const userData = result.data as User & { plan?: Plan; paymentHistory?: PaymentHistory[]; hasOnlyCancelledPlans?: boolean };
                             setIsAuthenticated(true);
                             setUser(result.data);
                             setPlan(userData.plan);
+                            setHasOnlyCancelledPlans(userData.hasOnlyCancelledPlans === true);
                             fetchUsageHistory();
                             setPaymentHistory(userData.paymentHistory || []);
                         } else {
@@ -119,10 +121,17 @@ export function useAuth() {
         }
     }, [fetchUsageHistory, fetchUserMe]);
 
-    const login = (userData: User, planData: Plan | undefined, usage: UsageHistory[], payment: PaymentHistory[]) => {
+    const login = (
+        userData: User,
+        planData: Plan | undefined,
+        usage: UsageHistory[],
+        payment: PaymentHistory[],
+        hasOnlyCancelledPlansValue: boolean = false,
+    ) => {
         setIsAuthenticated(true);
         setUser(userData);
         setPlan(planData);
+        setHasOnlyCancelledPlans(hasOnlyCancelledPlansValue);
         setUsageHistory(usage);
         setPaymentHistory(payment);
     };
@@ -144,6 +153,7 @@ export function useAuth() {
         setIsAuthenticated(false);
         setUser(undefined);
         setPlan(undefined);
+        setHasOnlyCancelledPlans(false);
         setUsageHistory([]);
         setPaymentHistory([]);
     };
@@ -151,9 +161,10 @@ export function useAuth() {
     const refreshUser = useCallback(async () => {
         const result = await fetchUserMe();
         if (result.data) {
-            const userData = result.data as User & { plan?: Plan; paymentHistory?: PaymentHistory[] };
+            const userData = result.data as User & { plan?: Plan; paymentHistory?: PaymentHistory[]; hasOnlyCancelledPlans?: boolean };
             setUser(result.data);
             setPlan(userData.plan);
+            setHasOnlyCancelledPlans(userData.hasOnlyCancelledPlans === true);
             setPaymentHistory(userData.paymentHistory || []);
         }
         return result.data;
@@ -164,6 +175,7 @@ export function useAuth() {
         isLoading,
         user,
         plan,
+        hasOnlyCancelledPlans,
         usageHistory,
         paymentHistory,
         setIsLoading,

--- a/frontend/src/hooks/useAuthHandlers.ts
+++ b/frontend/src/hooks/useAuthHandlers.ts
@@ -83,6 +83,7 @@ export const useAuthHandlers = (
             }
 
             let hasPlan = false
+            let isCancelledOnly = false
             try {
                 const userResponse = await fetch('/api/user/me', {
                     credentials: 'include',
@@ -91,7 +92,8 @@ export const useAuthHandlers = (
                 if (userResponse.ok) {
                     const userData = await userResponse.json()
                     hasPlan = userData.plan !== null && userData.plan !== undefined
-                    auth.login(userData, userData.plan, [], [])
+                    isCancelledOnly = userData.hasOnlyCancelledPlans === true
+                    auth.login(userData, userData.plan, [], [], isCancelledOnly)
                 }
             } catch {
                 // エラー処理
@@ -102,8 +104,9 @@ export const useAuthHandlers = (
                 return
             }
 
+            // cancelled のみのユーザーは home のバナーで再契約誘導するため、plan-registration に強制遷移しない
             let targetPath: string
-            if (!hasPlan) {
+            if (!hasPlan && !isCancelledOnly) {
                 targetPath = '/plan-registration'
             } else {
                 targetPath = '/home'

--- a/frontend/src/hooks/useAuthHandlers.ts
+++ b/frontend/src/hooks/useAuthHandlers.ts
@@ -93,7 +93,7 @@ export const useAuthHandlers = (
                     const userData = await userResponse.json()
                     hasPlan = userData.plan !== null && userData.plan !== undefined
                     isCancelledOnly = userData.hasOnlyCancelledPlans === true
-                    auth.login(userData, userData.plan, [], [], isCancelledOnly)
+                    auth.login(userData, userData.plan, [], [])
                 }
             } catch {
                 // エラー処理

--- a/frontend/src/hooks/useLoginPage.ts
+++ b/frontend/src/hooks/useLoginPage.ts
@@ -50,9 +50,11 @@ export const useLoginPage = () => {
         if (response.ok) {
           const userData = await response.json()
           const hasPlan = userData.plan !== null && userData.plan !== undefined
+          // cancelled のみのユーザーは home のバナーで再契約誘導するため、plan-registration に強制遷移しない
+          const isCancelledOnly = userData.hasOnlyCancelledPlans === true
 
           let targetPath: string
-          if (!hasPlan) {
+          if (!hasPlan && !isCancelledOnly) {
             // Cookieベースのセッション管理に変更したため、sessionStorageは使用しない
             targetPath = '/plan-registration'
           } else {

--- a/frontend/src/hooks/useVerifyOtpPage.ts
+++ b/frontend/src/hooks/useVerifyOtpPage.ts
@@ -121,12 +121,14 @@ export const useVerifyOtpPage = () => {
 
       // トークンはCookieに保存されているため、プラン登録状況を確認
       let hasPlan = false
+      let isCancelledOnly = false
       try {
         const userResponse = await fetch('/api/user/me')
 
         if (userResponse.ok) {
           const userData = await userResponse.json()
           hasPlan = userData.plan !== null && userData.plan !== undefined
+          isCancelledOnly = userData.hasOnlyCancelledPlans === true
         }
       } catch {
         // エラー処理
@@ -134,8 +136,9 @@ export const useVerifyOtpPage = () => {
 
       // リダイレクト先を決定
       // Cookieベースのセッション管理に変更したため、sessionStorageは使用しない
+      // cancelled のみのユーザーは home のバナーで再契約誘導するため、plan-registration に強制遷移しない
       let targetPath: string
-      if (!hasPlan) {
+      if (!hasPlan && !isCancelledOnly) {
         targetPath = '/plan-registration'
       } else {
         targetPath = '/home'

--- a/frontend/src/services/plan-registration.ts
+++ b/frontend/src/services/plan-registration.ts
@@ -12,6 +12,7 @@ export interface UserData {
   plan?: {
     status?: string
   } | null
+  hasOnlyCancelledPlans?: boolean
 }
 
 export interface CardRegisterResponse {

--- a/frontend/src/services/plan-registration.ts
+++ b/frontend/src/services/plan-registration.ts
@@ -12,7 +12,6 @@ export interface UserData {
   plan?: {
     status?: string
   } | null
-  hasOnlyCancelledPlans?: boolean
 }
 
 export interface CardRegisterResponse {


### PR DESCRIPTION
## 概要

`Account.status = active` かつ `user_plans` が全件 `cancelled` のユーザー（一時停止から継続課金停止に移行したユーザー）に対して、home 最上部に**再契約誘導バナー**を常時表示する。

## 背景

- `paused` → `cancelled` に遷移したユーザーは、`plan: null` になるため、従来はログイン後 `/plan-registration` に強制遷移していた
- しかし「決済失敗による契約中断」を明示的にユーザーへ伝える UI が無く、UX が不親切だった
- home 最上部にバナーを表示して状況を明示し、そこから再契約フローに進める導線を提供する

## 仕様

### バナー表示条件

`auth.hasOnlyCancelledPlans === true`（バックエンド `/me` の判定に依存）

### バナー文言

- タイトル: 「プランのご登録をお願いします」
- 本文: 「ご登録のお支払いカードで決済ができなかったため、現在ご契約中のプランがございません。再度プランをご登録ください。」
- CTA: 「プランを登録する」→ `/plan-registration` へ遷移

<img width="180" height="400" alt="image" src="https://github.com/user-attachments/assets/821916e1-0171-4af4-9cf7-6f42188bf258" />


### ログイン後の遷移フロー

| ユーザー状態 | 遷移先 |
|---|---|
| plan あり（active/paused/withdrawing） | `/home`（変更なし） |
| plan なし + `hasOnlyCancelledPlans: false`（新規未契約） | `/plan-registration`（変更なし） |
| plan なし + `hasOnlyCancelledPlans: true`（cancelled のみ） | **`/home`（新規）→ 再契約バナー表示** |

## 修正点

### 新規ファイル (1)

| ファイル | 役割 |
|---|---|
| `frontend/src/components/molecules/PlanCancelledNoticeBanner.tsx` | home 最上部の常時バナー |

### 編集ファイル (6)

| ファイル | 変更内容 |
|---|---|
| `frontend/src/hooks/useAuth.ts` | `hasOnlyCancelledPlans` state を追加、`initAuth` / `login` / `logout` / `refreshUser` / return に配線 |
| `frontend/src/services/plan-registration.ts` | `UserData` 型に `hasOnlyCancelledPlans?: boolean` を追加 |
| `frontend/src/components/templates/HomeLayout.tsx` | `isPlanCancelled` 判定と `<PlanCancelledNoticeBanner>` マウント。CTA は既存 `handlePlanRequiredModalRegister` を再利用 |
| `frontend/src/hooks/useLoginPage.ts` | 既ログイン時の自動遷移判定に `!isCancelledOnly` を追加 |
| `frontend/src/hooks/useAuthHandlers.ts` | メール認証完了時の遷移判定に `!isCancelledOnly` を追加。`auth.login()` にも渡す |
| `frontend/src/hooks/useVerifyOtpPage.ts` | OTP 認証完了時の遷移判定に `!isCancelledOnly` を追加 |


## 関連

- tamanomi-api :[#391](https://github.com/HV-development/tamanomi-api/pull/391)
- nomoca-kagawa-web :[#161](https://github.com/HV-development/nomoca-kagawa-web/pull/161)