### PR TITLE
[追加開発①]　無料期間キャンペーンの BFF Route Handler を追加

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
-    "@hv-development/schemas": "1.139.0",
+    "@hv-development/schemas": "^1.140.0",
     "@radix-ui/react-accordion": "1.2.2",
     "@radix-ui/react-alert-dialog": "1.1.4",
     "@radix-ui/react-aspect-ratio": "1.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
-    "@hv-development/schemas": "^1.140.0",
+    "@hv-development/schemas": "1.140.0",
     "@radix-ui/react-accordion": "1.2.2",
     "@radix-ui/react-alert-dialog": "1.1.4",
     "@radix-ui/react-aspect-ratio": "1.1.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -13,8 +13,8 @@ dependencies:
     specifier: ^3.10.0
     version: 3.10.0(react-hook-form@7.68.0)
   '@hv-development/schemas':
-    specifier: 1.139.0
-    version: 1.139.0
+    specifier: 1.140.0
+    version: 1.140.0
   '@radix-ui/react-accordion':
     specifier: 1.2.2
     version: 1.2.2(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1)
@@ -579,8 +579,8 @@ packages:
     deprecated: Use @eslint/object-schema instead
     dev: true
 
-  /@hv-development/schemas@1.139.0:
-    resolution: {integrity: sha512-kpUq6FE7nEu/aHn8RaUCEKSZniFesj+C46qc2ddRIAmY1vqPw+q1jtQxoyYJGSVFviSZSfdTkC9Jz1GT+1W7Sg==, tarball: https://npm.pkg.github.com/download/@hv-development/schemas/1.139.0/2d4e8e2223dba82448beeffef756d638f298dd5f}
+  /@hv-development/schemas@1.140.0:
+    resolution: {integrity: sha512-zx17/5cnDPPLECNz9zD/yhbnjBfJL4JzYjnYRF6oKJ18s1o04mwqMs93TBOuyRPL6ys273KH5qutHzgHs/FVpw==, tarball: https://npm.pkg.github.com/download/@hv-development/schemas/1.140.0/5f957f0e5cb7adb5eb50290eaba027e5d09dde9d}
     engines: {node: 22.x}
     dependencies:
       zod: 3.25.76

--- a/frontend/src/app/api/campaigns/me/current/route.ts
+++ b/frontend/src/app/api/campaigns/me/current/route.ts
@@ -23,7 +23,11 @@ export async function GET(request: NextRequest) {
     const data = await response.json().catch(() => ({}))
 
     if (!response.ok) {
-      return createNoCacheResponse(data, { status: response.status })
+      console.error('❌ [campaigns/me/current] Backend API error:', data)
+      return createNoCacheResponse(
+        { error: data.message || data.error?.message || 'キャンペーン情報の取得に失敗しました' },
+        { status: response.status }
+      )
     }
 
     return createNoCacheResponse(data)

--- a/frontend/src/app/api/campaigns/me/current/route.ts
+++ b/frontend/src/app/api/campaigns/me/current/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest } from 'next/server'
+import { buildApiUrl } from '@/lib/api-config'
+import { secureFetchWithCommonHeaders } from '@/lib/fetch-utils'
+import { createNoCacheResponse } from '@/lib/response-utils'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: NextRequest) {
+  try {
+    const fullUrl = buildApiUrl('/campaigns/me/current')
+
+    const response = await secureFetchWithCommonHeaders(request, fullUrl, {
+      method: 'GET',
+      headerOptions: {
+        requireAuth: true,
+      },
+    })
+
+    if (response.status === 401) {
+      return createNoCacheResponse({ error: '認証が必要です' }, { status: 401 })
+    }
+
+    const data = await response.json().catch(() => ({}))
+
+    if (!response.ok) {
+      return createNoCacheResponse(data, { status: response.status })
+    }
+
+    return createNoCacheResponse(data)
+  } catch (error) {
+    console.error('Campaigns me/current API fetch error:', error)
+    return createNoCacheResponse(
+      { error: 'キャンペーン情報の取得中にエラーが発生しました' },
+      { status: 500 }
+    )
+  }
+}

--- a/frontend/src/app/api/campaigns/validate/route.ts
+++ b/frontend/src/app/api/campaigns/validate/route.ts
@@ -48,7 +48,7 @@ export async function POST(request: NextRequest) {
 
     if (response.status === 401) {
       return createNoCacheResponse(
-        { error: '認証が必要です' },
+        { error: { code: 'UNAUTHORIZED', message: '認証が必要です。再ログインしてください' } },
         { status: 401 }
       )
     }
@@ -58,7 +58,15 @@ export async function POST(request: NextRequest) {
     if (!response.ok) {
       console.error('❌ [campaigns/validate] Backend API error:', data)
       return createNoCacheResponse(
-        { error: data.message || data.error?.message || 'キャンペーンコードの検証に失敗しました' },
+        {
+          error: {
+            code: data.error?.code || 'CAMPAIGN_VALIDATE_FAILED',
+            message:
+              data.error?.message ||
+              data.message ||
+              'キャンペーンコードの検証に失敗しました',
+          },
+        },
         { status: response.status }
       )
     }
@@ -67,7 +75,7 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     console.error('Campaign validate API fetch error:', error)
     return createNoCacheResponse(
-      { error: 'キャンペーンコードの検証中にエラーが発生しました' },
+      { error: { code: 'INTERNAL_ERROR', message: 'キャンペーンコードの検証中にエラーが発生しました' } },
       { status: 500 }
     )
   }

--- a/frontend/src/app/api/campaigns/validate/route.ts
+++ b/frontend/src/app/api/campaigns/validate/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest } from 'next/server'
+import { campaignValidateRequestSchema } from '@hv-development/schemas'
 import { buildApiUrl } from '@/lib/api-config'
 import { secureFetchWithCommonHeaders } from '@/lib/fetch-utils'
 import { createNoCacheResponse } from '@/lib/response-utils'
@@ -6,16 +7,34 @@ import { createNoCacheResponse } from '@/lib/response-utils'
 export const dynamic = 'force-dynamic'
 
 export async function POST(request: NextRequest) {
+  let body: unknown
   try {
-    const body = await request.json()
-    const { code } = body
+    body = await request.json()
+  } catch {
+    return createNoCacheResponse(
+      {
+        valid: false,
+        reason: 'MALFORMED_REQUEST',
+        message: 'リクエスト形式が不正です',
+      },
+      { status: 400 }
+    )
+  }
 
-    if (!code || typeof code !== 'string') {
-      return createNoCacheResponse(
-        { error: 'コードを入力してください' },
-        { status: 400 }
-      )
-    }
+  const parseResult = campaignValidateRequestSchema.safeParse(body)
+  if (!parseResult.success) {
+    return createNoCacheResponse(
+      {
+        valid: false,
+        reason: 'MISSING_CODE',
+        message: 'コードを入力してください',
+      },
+      { status: 400 }
+    )
+  }
+
+  try {
+    const { code } = parseResult.data
 
     const fullUrl = buildApiUrl('/campaigns/validate')
 
@@ -37,7 +56,11 @@ export async function POST(request: NextRequest) {
     const data = await response.json().catch(() => ({}))
 
     if (!response.ok) {
-      return createNoCacheResponse(data, { status: response.status })
+      console.error('❌ [campaigns/validate] Backend API error:', data)
+      return createNoCacheResponse(
+        { error: data.message || data.error?.message || 'キャンペーンコードの検証に失敗しました' },
+        { status: response.status }
+      )
     }
 
     return createNoCacheResponse(data)

--- a/frontend/src/app/api/campaigns/validate/route.ts
+++ b/frontend/src/app/api/campaigns/validate/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest } from 'next/server'
+import { buildApiUrl } from '@/lib/api-config'
+import { secureFetchWithCommonHeaders } from '@/lib/fetch-utils'
+import { createNoCacheResponse } from '@/lib/response-utils'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const { code } = body
+
+    if (!code || typeof code !== 'string') {
+      return createNoCacheResponse(
+        { error: 'コードを入力してください' },
+        { status: 400 }
+      )
+    }
+
+    const fullUrl = buildApiUrl('/campaigns/validate')
+
+    const response = await secureFetchWithCommonHeaders(request, fullUrl, {
+      method: 'POST',
+      headerOptions: {
+        requireAuth: true,
+      },
+      body: JSON.stringify({ code }),
+    })
+
+    if (response.status === 401) {
+      return createNoCacheResponse(
+        { error: '認証が必要です' },
+        { status: 401 }
+      )
+    }
+
+    const data = await response.json().catch(() => ({}))
+
+    if (!response.ok) {
+      return createNoCacheResponse(data, { status: response.status })
+    }
+
+    return createNoCacheResponse(data)
+  } catch (error) {
+    console.error('Campaign validate API fetch error:', error)
+    return createNoCacheResponse(
+      { error: 'キャンペーンコードの検証中にエラーが発生しました' },
+      { status: 500 }
+    )
+  }
+}

--- a/frontend/src/app/api/payment/register/route.ts
+++ b/frontend/src/app/api/payment/register/route.ts
@@ -38,8 +38,11 @@ export async function POST(request: NextRequest) {
       backendRequestBody.companyName = companyName
     }
 
-    if (campaignCode) {
-      backendRequestBody.campaignCode = campaignCode
+    // 多層防御: backend でも trim するが、BFF 側で早期に前後空白を弾く
+    const trimmedCampaignCode = typeof campaignCode === 'string' ? campaignCode.trim() : undefined
+
+    if (trimmedCampaignCode) {
+      backendRequestBody.campaignCode = trimmedCampaignCode
     }
 
     const response = await secureFetchWithCommonHeaders(request, fullUrl, {

--- a/frontend/src/app/api/payment/register/route.ts
+++ b/frontend/src/app/api/payment/register/route.ts
@@ -8,7 +8,7 @@ export const dynamic = 'force-dynamic'
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
-    const { customerId, planId, customerFamilyName, customerName, companyName } = body
+    const { customerId, planId, customerFamilyName, customerName, companyName, campaignCode } = body
 
 
     // API_BASE_URLから末尾の/api/v1を削除（重複を防ぐ）
@@ -36,6 +36,10 @@ export async function POST(request: NextRequest) {
 
     if (companyName) {
       backendRequestBody.companyName = companyName
+    }
+
+    if (campaignCode) {
+      backendRequestBody.campaignCode = campaignCode
     }
 
     const response = await secureFetchWithCommonHeaders(request, fullUrl, {


### PR DESCRIPTION
## 概要

無料期間キャンペーン機能の BFF（Backend For Frontend）Route Handler を追加。
`GET /api/campaigns/me/current` と `POST /api/campaigns/validate` の proxy、および `POST /api/payment/register` に campaignCode 通過ロジックを追加する。

## 背景

- 無料期間キャンペーン機能の web 側 UI が tamanomi-api の Campaign 系エンドポイントを呼び出す必要がある
- Next.js の Route Handler で認証 Cookie を付与しつつ proxy する構造

## 修正点

### 編集ファイル (1 commit)

| commit | 内容 |
|---|---|
| BFF Route Handler 追加 + payment/register に campaignCode 通過 | GET /api/campaigns/me/current と POST /api/campaigns/validate の Route Handler を新規追加。POST /api/payment/register で campaignCode をリクエストボディに含めるよう修正 |

## 関連

- API 本体: tamanomi-api / feature/campaigns-user-api
- 型定義: tamanomi-schemas / feature/free-campaign
- 続く再導入 PR: プラン登録・完了画面、プラン管理画面、ヘッダー判定切替