### PR TITLE
[追加開発②]　プラン登録・カード登録完了画面にキャンペーン UI を追加

### DIFF
--- a/frontend/src/app/payment-return/page.tsx
+++ b/frontend/src/app/payment-return/page.tsx
@@ -5,13 +5,14 @@ import { usePaymentReturn } from '@/hooks/usePaymentReturn'
 import { PaymentReturnContainer } from '@/components/organisms/PaymentReturnContainer'
 
 function PaymentReturnContent() {
-  const { isProcessing, error, isPaymentMethodChangeOnly } = usePaymentReturn()
+  const { isProcessing, error, isPaymentMethodChangeOnly, campaignInfo } = usePaymentReturn()
 
   return (
     <PaymentReturnContainer
       isProcessing={isProcessing}
       error={error}
       isPaymentMethodChangeOnly={isPaymentMethodChangeOnly}
+      campaignInfo={campaignInfo}
     />
   )
 }

--- a/frontend/src/app/plan-registration/page.tsx
+++ b/frontend/src/app/plan-registration/page.tsx
@@ -12,6 +12,7 @@ export default function PlanRegistrationPage() {
     saitamaAppLinked,
     hasPaymentMethod,
     isPaymentMethodChangeOnly,
+    isNewSignupFlow,
     handlePaymentMethodRegister,
     handleSaitamaAppLinked,
     handleCancel,
@@ -42,6 +43,7 @@ export default function PlanRegistrationPage() {
       onSaitamaAppLinked={handleSaitamaAppLinked}
       hasPaymentMethod={hasPaymentMethod}
       isPaymentMethodChangeOnly={isPaymentMethodChangeOnly}
+      isNewSignupFlow={isNewSignupFlow}
     />
   )
 }

--- a/frontend/src/app/register-confirmation/page.tsx
+++ b/frontend/src/app/register-confirmation/page.tsx
@@ -184,9 +184,9 @@ export default function RegisterConfirmationPage() {
           // Cookieベースのセッション管理に変更したため、sessionStorageは使用しない
           // window.location.hrefを使用して強制的に遷移
           if (typeof window !== 'undefined') {
-            window.location.href = '/plan-registration'
+            window.location.href = '/plan-registration?flow=signup'
           } else {
-            router.push('/plan-registration')
+            router.push('/plan-registration?flow=signup')
           }
         }
       } else {
@@ -224,9 +224,9 @@ export default function RegisterConfirmationPage() {
     // Cookieベースのセッション管理に変更したため、sessionStorageは使用しない
     // window.location.hrefを使用して強制的に遷移
     if (typeof window !== 'undefined') {
-      window.location.href = '/plan-registration?saitamaAppLinked=true'
+      window.location.href = '/plan-registration?flow=signup&saitamaAppLinked=true'
     } else {
-      router.push('/plan-registration?saitamaAppLinked=true')
+      router.push('/plan-registration?flow=signup&saitamaAppLinked=true')
     }
   }
 
@@ -235,9 +235,9 @@ export default function RegisterConfirmationPage() {
     // さいたま市アプリ連携なしでプラン登録画面に遷移
     // Cookieベースのセッション管理に変更したため、sessionStorageは使用しない
     if (typeof window !== 'undefined') {
-      window.location.href = '/plan-registration'
+      window.location.href = '/plan-registration?flow=signup'
     } else {
-      router.push('/plan-registration')
+      router.push('/plan-registration?flow=signup')
     }
   }
 

--- a/frontend/src/components/molecules/CampaignCodeCard.tsx
+++ b/frontend/src/components/molecules/CampaignCodeCard.tsx
@@ -1,0 +1,184 @@
+"use client"
+
+import { useState } from "react"
+import { Check } from "lucide-react"
+import { ApiClient } from "@/lib/api-client"
+
+export interface AppliedCampaign {
+  id: string
+  name: string
+  freeDays: number
+  code: string
+}
+
+interface CampaignCodeCardProps {
+  appliedCampaign: AppliedCampaign | null
+  onApplied: (campaign: AppliedCampaign) => void
+  onCleared: () => void
+}
+
+interface ValidateSuccessResponse {
+  valid: true
+  campaign: { id: string; name: string; freeDays: number }
+  display: { priceMain: string; pricePeriod: string; priceNote: string }
+}
+
+interface ValidateFailureResponse {
+  valid: false
+  reason: 'INVALID_CODE' | 'ALREADY_REDEEMED'
+  message: string
+}
+
+type ValidateResponse = ValidateSuccessResponse | ValidateFailureResponse
+
+const CODE_PATTERN = /^[a-z0-9]{6,20}$/
+
+export function CampaignCodeCard({ appliedCampaign, onApplied, onCleared }: CampaignCodeCardProps) {
+  const [code, setCode] = useState<string>("")
+  const [errorMessage, setErrorMessage] = useState<string>("")
+  const [isApplying, setIsApplying] = useState<boolean>(false)
+
+  const isApplied = appliedCampaign !== null
+  const displayFreeDays = appliedCampaign?.freeDays ?? 30
+  const displayNextDay = displayFreeDays + 1
+
+  const handleChange = (value: string) => {
+    setCode(value.slice(0, 40))
+    if (errorMessage) setErrorMessage("")
+  }
+
+  const handleApply = async () => {
+    const normalized = code.trim().toLowerCase()
+    if (!normalized) {
+      setErrorMessage("キャンペーンコードは必須です")
+      return
+    }
+    if (!CODE_PATTERN.test(normalized)) {
+      setErrorMessage("6〜20文字の英小文字・半角数字で入力してください")
+      return
+    }
+
+    setIsApplying(true)
+    setErrorMessage("")
+
+    const result = await ApiClient.post<ValidateResponse>('/api/campaigns/validate', { code: normalized })
+
+    setIsApplying(false)
+
+    if (result.error) {
+      setErrorMessage(result.error.message || "検証に失敗しました")
+      return
+    }
+
+    const data = result.data
+    if (!data) {
+      setErrorMessage("検証に失敗しました")
+      return
+    }
+
+    if (data.valid) {
+      onApplied({
+        id: data.campaign.id,
+        name: data.campaign.name,
+        freeDays: data.campaign.freeDays,
+        code: normalized,
+      })
+      setCode(normalized)
+      return
+    }
+
+    if (data.reason === 'INVALID_CODE') {
+      setErrorMessage("このコードは無効です")
+    } else if (data.reason === 'ALREADY_REDEEMED') {
+      setErrorMessage("すでにキャンペーンをご利用済みです")
+    } else {
+      setErrorMessage(data.message || "コードが無効です")
+    }
+  }
+
+  const handleClear = () => {
+    setCode("")
+    setErrorMessage("")
+    onCleared()
+  }
+
+  return (
+    <div className="w-full rounded-2xl border border-[#d9d9d9] bg-white p-6 space-y-4">
+      <div className="space-y-3">
+        <p className="text-base font-semibold text-black">キャンペーンコードをお持ちですか？</p>
+        <div className="flex items-end gap-1">
+          <p className="text-[24px] font-semibold leading-none text-[#049a2a]">￥0</p>
+          <p className="text-[12px] text-[#a6a6a6]">/最初の{displayFreeDays}日間</p>
+        </div>
+        <p className="text-[12px] text-[#a6a6a6]">{displayNextDay}日目以降はプラン料金</p>
+      </div>
+
+      <div className="space-y-1.5">
+        <div className="flex items-start gap-2">
+          <div className="flex-1 space-y-1.5">
+            <div
+              className={`relative flex h-10 items-center rounded-[10px] border px-3 ${
+                isApplied ? "border-[#049a2a] bg-white" : "border-[#d9d9d9] bg-white"
+              }`}
+            >
+              <input
+                type="text"
+                value={code}
+                onChange={(e) => handleChange(e.target.value)}
+                placeholder="キャンペーンコード"
+                disabled={isApplied || isApplying}
+                className="flex-1 bg-transparent text-base font-medium text-black placeholder:text-[#9aa39a] focus:outline-none disabled:cursor-not-allowed"
+                inputMode="text"
+                autoComplete="off"
+                autoCapitalize="off"
+                autoCorrect="off"
+                spellCheck={false}
+              />
+              {isApplied && (
+                <Check className="h-4 w-4 flex-shrink-0 text-[#049a2a]" strokeWidth={3} />
+              )}
+            </div>
+            {errorMessage && (
+              <p className="text-xs text-[#ea3323]">{errorMessage}</p>
+            )}
+          </div>
+          {isApplied ? (
+            <button
+              type="button"
+              onClick={handleClear}
+              className="shrink-0 rounded-lg border border-[#049a2a] bg-[#f0fdf4] px-2 py-3 text-sm font-semibold text-[#049a2a]"
+            >
+              適用済み
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={handleApply}
+              disabled={isApplying}
+              className="shrink-0 rounded-lg bg-[#049a2a] px-2 py-3 text-sm font-semibold text-white disabled:opacity-60"
+            >
+              {isApplying ? "確認中..." : "適用する"}
+            </button>
+          )}
+        </div>
+        <div className="flex justify-start">
+          <a
+            href="/lp/faq"
+            className="inline-block border-b border-[#3273f6] pb-[2px] text-[10px] text-[#3273f6]"
+          >
+            キャンペーンについてはこちら
+          </a>
+        </div>
+      </div>
+
+      {isApplied && (
+        <div className="flex items-center justify-center gap-2 rounded-lg border border-[rgba(4,154,42,0.24)] bg-[#f0fdf4] p-2.5">
+          <Check className="h-4 w-4 text-[#049a2a]" strokeWidth={3} />
+          <p className="text-xs font-bold text-[#33803f]">
+            最初の{displayFreeDays}日間無料 でご利用いただけます！
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/organisms/PlanManagementContainer.tsx
+++ b/frontend/src/components/organisms/PlanManagementContainer.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { HeaderLogo } from "../atoms/HeaderLogo"
-import { PlanManagement } from "@/components/molecules/PlanManagement"
+import { PlanManagement, type PlanManagementCampaignInfo } from "@/components/molecules/PlanManagement"
 import type { Plan } from "@/types/user"
 
 interface PlanManagementContainerProps {
@@ -13,6 +13,7 @@ interface PlanManagementContainerProps {
   onBack: () => void
   onLogoClick: () => void
   backgroundColorClass?: string
+  campaignInfo?: PlanManagementCampaignInfo | null
 }
 
 export function PlanManagementContainer({
@@ -24,6 +25,7 @@ export function PlanManagementContainer({
   onBack,
   onLogoClick,
   backgroundColorClass = "bg-gradient-to-br from-green-50 to-green-100",
+  campaignInfo,
 }: PlanManagementContainerProps) {
   return (
     <div className={`min-h-screen ${backgroundColorClass}`}>
@@ -31,12 +33,13 @@ export function PlanManagementContainer({
       <HeaderLogo onLogoClick={onLogoClick} showBackButton={true} onBackClick={onBack} />
 
       <div className="p-4 max-w-md mx-auto">
-        <PlanManagement 
-          plan={plan} 
-          onChangePlan={onChangePlan} 
+        <PlanManagement
+          plan={plan}
+          onChangePlan={onChangePlan}
           onCancelSubscription={onCancelSubscription}
           onChangePaymentMethod={onChangePaymentMethod}
           hasPaymentMethod={hasPaymentMethod}
+          campaignInfo={campaignInfo}
         />
       </div>
     </div>

--- a/frontend/src/components/organisms/PlanRegistrationContainer.tsx
+++ b/frontend/src/components/organisms/PlanRegistrationContainer.tsx
@@ -36,12 +36,9 @@ export function PlanRegistrationContainer({
 }: PlanRegistrationContainerProps) {
   return (
     <div className={`min-h-screen ${backgroundColorClass} flex flex-col`}>
-      {/* ヘッダー */}
-      <HeaderLogo
-        onLogoClick={onLogoClick}
-        showBackButton={!isNewSignupFlow}
-        onBackClick={onCancel}
-      />
+      {!isNewSignupFlow && (
+        <HeaderLogo onLogoClick={onLogoClick} showBackButton={true} onBackClick={onCancel} />
+      )}
 
       {/* メインコンテンツ */}
       <div className="flex-1 flex items-center justify-center p-4">

--- a/frontend/src/components/organisms/PlanRegistrationContainer.tsx
+++ b/frontend/src/components/organisms/PlanRegistrationContainer.tsx
@@ -6,7 +6,7 @@ import type { PaymentMethodType } from '@hv-development/schemas'
 import { PlanListResponse } from '@hv-development/schemas'
 
 interface PlanRegistrationContainerProps {
-  onPaymentMethodRegister: (planId: string, paymentMethod: PaymentMethodType) => void
+  onPaymentMethodRegister: (planId: string, paymentMethod: PaymentMethodType, campaignCode?: string) => void
   onCancel: () => void
   onLogoClick: () => void
   isLoading?: boolean
@@ -17,6 +17,7 @@ interface PlanRegistrationContainerProps {
   onSaitamaAppLinked?: () => void
   hasPaymentMethod?: boolean
   isPaymentMethodChangeOnly?: boolean
+  isNewSignupFlow?: boolean
 }
 
 export function PlanRegistrationContainer({
@@ -31,11 +32,16 @@ export function PlanRegistrationContainer({
   onSaitamaAppLinked,
   hasPaymentMethod,
   isPaymentMethodChangeOnly,
+  isNewSignupFlow,
 }: PlanRegistrationContainerProps) {
   return (
     <div className={`min-h-screen ${backgroundColorClass} flex flex-col`}>
       {/* ヘッダー */}
-      <HeaderLogo onLogoClick={onLogoClick} showBackButton={true} onBackClick={onCancel} />
+      <HeaderLogo
+        onLogoClick={onLogoClick}
+        showBackButton={!isNewSignupFlow}
+        onBackClick={onCancel}
+      />
 
       {/* メインコンテンツ */}
       <div className="flex-1 flex items-center justify-center p-4">

--- a/frontend/src/components/organisms/PlanRegistrationForm.tsx
+++ b/frontend/src/components/organisms/PlanRegistrationForm.tsx
@@ -121,7 +121,8 @@ export function PlanRegistrationForm({
     }
 
     if (selectedPlan || isPaymentMethodChangeOnly) {
-      onPaymentMethodRegister(selectedPlan, selectedPaymentMethod, appliedCampaign?.code)
+      const campaignCode = selectedPlanData?.is_subscription ? appliedCampaign?.code : undefined
+      onPaymentMethodRegister(selectedPlan, selectedPaymentMethod, campaignCode)
     }
   }
 

--- a/frontend/src/components/organisms/PlanRegistrationForm.tsx
+++ b/frontend/src/components/organisms/PlanRegistrationForm.tsx
@@ -4,6 +4,7 @@ import { CreditCard, AlertCircle, CheckCircle, Smartphone, QrCode } from "lucide
 import { useState, useEffect, useRef } from "react"
 import Image from "next/image"
 import { PlanCard } from "@/components/molecules/PlanCard"
+import { CampaignCodeCard, type AppliedCampaign } from "@/components/molecules/CampaignCodeCard"
 import { Button } from "@/components/atoms/Button"
 import { Input } from "@/components/atoms/Input"
 import { Modal } from "@/components/atoms/Modal"
@@ -13,7 +14,7 @@ import type { PaymentMethodType } from '@hv-development/schemas'
 import { ApiClient } from '@/lib/api-client';
 
 interface PlanRegistrationFormProps {
-  onPaymentMethodRegister: (planId: string, paymentMethod: PaymentMethodType) => void
+  onPaymentMethodRegister: (planId: string, paymentMethod: PaymentMethodType, campaignCode?: string) => void
   onCancel: () => void
   isLoading?: boolean
   plans: PlanListResponse['plans']
@@ -77,6 +78,7 @@ export function PlanRegistrationForm({
   const [modalMessage, setModalMessage] = useState<string>("")
   const [selectedPaymentMethod, setSelectedPaymentMethod] = useState<PaymentMethodType>('CreditCard')
   const [allPlansDisplayed, setAllPlansDisplayed] = useState(false)
+  const [appliedCampaign, setAppliedCampaign] = useState<AppliedCampaign | null>(null)
   const displayedPlansCount = useRef(0)
 
   // 選択中のプランがサブスクリプションプランかを判定
@@ -119,7 +121,7 @@ export function PlanRegistrationForm({
     }
 
     if (selectedPlan || isPaymentMethodChangeOnly) {
-      onPaymentMethodRegister(selectedPlan, selectedPaymentMethod)
+      onPaymentMethodRegister(selectedPlan, selectedPaymentMethod, appliedCampaign?.code)
     }
   }
 
@@ -196,6 +198,15 @@ export function PlanRegistrationForm({
         </div>
       )}
 
+      {/* キャンペーンコード入力カード */}
+      {!isPaymentMethodChangeOnly && (
+        <CampaignCodeCard
+          appliedCampaign={appliedCampaign}
+          onApplied={setAppliedCampaign}
+          onCleared={() => setAppliedCampaign(null)}
+        />
+      )}
+
       {/* 連携完了表示（連携済みまたは連携したIDがある場合、支払い方法変更のみの場合は非表示） */}
       {!isPaymentMethodChangeOnly && (saitamaAppLinked || linkedSaitamaAppId) && (
         <div className="bg-gradient-to-br from-green-50 to-green-100 border border-green-200 rounded-lg p-4">
@@ -231,16 +242,20 @@ export function PlanRegistrationForm({
             const isSaitamaLinked = saitamaAppLinked || linkedSaitamaAppId;
             const saitamaDiscountPrice = 480; // さいたま市アプリ連携時の価格
             
+            const campaignActive = appliedCampaign !== null && plan.is_subscription
+
             // さいたま市アプリ連携済みで、通常価格が980円の場合
             if (isSaitamaLinked && plan.price === 980) {
+              const effectiveOriginal = `¥${saitamaDiscountPrice.toLocaleString()}${plan.is_subscription ? '/月' : ''}`
+              const campaignPrice = `¥0/最初の${appliedCampaign?.freeDays ?? 30}日間`
               return (
                 <PlanFadeIn key={plan.id} delay={index * 100} onDisplayed={handlePlanDisplayed}>
                   <PlanCard
                     title={plan.name}
                     description={plan.description || ''}
                     features={plan.plan_content?.features || []}
-                    price={`¥${saitamaDiscountPrice.toLocaleString()}${plan.is_subscription ? '/月' : ''}`}
-                    originalPrice={`¥${plan.price.toLocaleString()}${plan.is_subscription ? '/月' : ''}`}
+                    price={campaignActive ? campaignPrice : effectiveOriginal}
+                    originalPrice={campaignActive ? effectiveOriginal : `¥${plan.price.toLocaleString()}${plan.is_subscription ? '/月' : ''}`}
                     badge={plan.status === 'active' ? 'さいたま市アプリ連携でお得' : undefined}
                     isSelected={selectedPlan === plan.id}
                     onSelect={() => handlePlanSelect(plan.id)}
@@ -248,15 +263,17 @@ export function PlanRegistrationForm({
                 </PlanFadeIn>
               );
             }
-            
+
+            const normalPrice = `¥${displayPrice.toLocaleString()}${plan.is_subscription ? '/月' : ''}`
+            const campaignPrice = `¥0/最初の${appliedCampaign?.freeDays ?? 30}日間`
             return (
               <PlanFadeIn key={plan.id} delay={index * 100} onDisplayed={handlePlanDisplayed}>
                 <PlanCard
                   title={plan.name}
                   description={plan.description || ''}
                   features={plan.plan_content?.features || []}
-                  price={`¥${displayPrice.toLocaleString()}${plan.is_subscription ? '/月' : ''}`}
-                  originalPrice={hasDiscount ? `¥${plan.price.toLocaleString()}${plan.is_subscription ? '/月' : ''}` : undefined}
+                  price={campaignActive ? campaignPrice : normalPrice}
+                  originalPrice={campaignActive ? normalPrice : (hasDiscount ? `¥${plan.price.toLocaleString()}${plan.is_subscription ? '/月' : ''}` : undefined)}
                   badge={plan.status === 'active' ? '利用可能' : undefined}
                   isSelected={selectedPlan === plan.id}
                   onSelect={() => handlePlanSelect(plan.id)}

--- a/frontend/src/hooks/usePaymentReturn.ts
+++ b/frontend/src/hooks/usePaymentReturn.ts
@@ -3,12 +3,22 @@
 import { useState, useEffect, useRef } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 
+export interface CampaignInfo {
+  freeDaysApplied: number
+  firstBillingDate: string
+  appliedAt: string
+  campaignName: string
+  planName: string
+  planPrice: number
+}
+
 export const usePaymentReturn = () => {
   const router = useRouter()
   const searchParams = useSearchParams()
   const [isProcessing, setIsProcessing] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [isPaymentMethodChangeOnly, setIsPaymentMethodChangeOnly] = useState(false)
+  const [campaignInfo, setCampaignInfo] = useState<CampaignInfo | null>(null)
   const hasProcessedRef = useRef(false)
   const isProcessingRef = useRef(false)
 
@@ -132,6 +142,35 @@ export const usePaymentReturn = () => {
         hasProcessedRef.current = true
         isProcessingRef.current = false
 
+        // キャンペーン適用チェック（プラン新規登録時のみ）
+        let hasCampaign = false
+        if (!isPaymentMethodChange) {
+          try {
+            const campaignResponse = await fetch('/api/campaigns/me/current', { credentials: 'include' })
+            if (campaignResponse.ok) {
+              const data = await campaignResponse.json()
+              if (data?.hasActiveCampaign && data.application) {
+                hasCampaign = true
+                setCampaignInfo({
+                  freeDaysApplied: data.application.freeDaysApplied,
+                  firstBillingDate: data.application.firstBillingDate,
+                  appliedAt: data.application.appliedAt,
+                  campaignName: data.application.campaign?.name ?? '',
+                  planName: data.application.plan?.name ?? '',
+                  planPrice: data.application.plan?.price ?? 0,
+                })
+              }
+            }
+          } catch {
+            // キャンペーン取得失敗は無視して通常フローへ
+          }
+        }
+
+        // キャンペーン適用時は自動遷移しない（ユーザーがボタンを押すまで待機）
+        if (hasCampaign) {
+          return
+        }
+
         // 2秒後にリダイレクト
         setTimeout(() => {
           if (isPaymentMethodChangeOnly) {
@@ -157,6 +196,7 @@ export const usePaymentReturn = () => {
     isProcessing,
     error,
     isPaymentMethodChangeOnly,
+    campaignInfo,
   }
 }
 

--- a/frontend/src/hooks/usePaymentReturn.ts
+++ b/frontend/src/hooks/usePaymentReturn.ts
@@ -137,12 +137,7 @@ export const usePaymentReturn = () => {
 
         // セキュリティ改善：sessionStorageの使用を廃止（削除処理も不要）
 
-        // 処理完了
-        setIsProcessing(false)
-        hasProcessedRef.current = true
-        isProcessingRef.current = false
-
-        // キャンペーン適用チェック（プラン新規登録時のみ）
+        // isProcessing 解除前にキャンペーン適用有無を確定させて画面のチラつきを防ぐ。
         let hasCampaign = false
         if (!isPaymentMethodChange) {
           try {
@@ -165,6 +160,10 @@ export const usePaymentReturn = () => {
             // キャンペーン取得失敗は無視して通常フローへ
           }
         }
+
+        setIsProcessing(false)
+        hasProcessedRef.current = true
+        isProcessingRef.current = false
 
         // キャンペーン適用時は自動遷移しない（ユーザーがボタンを押すまで待機）
         if (hasCampaign) {

--- a/frontend/src/hooks/usePlanRegistration.ts
+++ b/frontend/src/hooks/usePlanRegistration.ts
@@ -47,6 +47,7 @@ export function usePlanRegistration() {
   const [saitamaAppLinked, setSaitamaAppLinked] = useState<boolean | null>(null)
   const [hasPaymentMethod, setHasPaymentMethod] = useState<boolean>(false)
   const [isPaymentMethodChangeOnly, setIsPaymentMethodChangeOnly] = useState<boolean>(false)
+  const [isNewSignupFlow, setIsNewSignupFlow] = useState<boolean>(false)
   const [userId, setUserId] = useState<string>('')
   const router = useRouter()
 
@@ -114,6 +115,10 @@ export function usePlanRegistration() {
 
     if (urlParams.get('saitamaAppLinked') === 'true') {
       setSaitamaAppLinked(true)
+    }
+
+    if (urlParams.get('flow') === 'signup') {
+      setIsNewSignupFlow(true)
     }
 
     refreshUserInfo()
@@ -254,12 +259,14 @@ export function usePlanRegistration() {
   const processCreditCard = async (
     currentEmail: string,
     planId: string | undefined,
+    campaignCode?: string,
   ) => {
     const customerId = generateCustomerId(currentEmail)
     const data = await registerCreditCard({
       customerId,
       userEmail: currentEmail,
       planId,
+      campaignCode,
     })
 
     const { redirectUrl, params } = data
@@ -287,7 +294,11 @@ export function usePlanRegistration() {
   }
 
   // --- メインハンドラ ---
-  const handlePaymentMethodRegister = async (planId: string, paymentMethod: PaymentMethodType) => {
+  const handlePaymentMethodRegister = async (
+    planId: string,
+    paymentMethod: PaymentMethodType,
+    campaignCode?: string,
+  ) => {
     if (isLoading) return
 
     try {
@@ -355,7 +366,7 @@ export function usePlanRegistration() {
           await processPayPay(currentUserId, planId, paymentAmount)
         }
       } else {
-        await processCreditCard(currentEmail, isChangeOnly ? undefined : planId)
+        await processCreditCard(currentEmail, isChangeOnly ? undefined : planId, campaignCode)
       }
     } catch (err) {
       console.error('▲ERROR [handlePaymentMethodRegister]:', err)
@@ -397,6 +408,7 @@ export function usePlanRegistration() {
     saitamaAppLinked,
     hasPaymentMethod,
     isPaymentMethodChangeOnly,
+    isNewSignupFlow,
     handlePaymentMethodRegister,
     handleSaitamaAppLinked,
     handleCancel,

--- a/frontend/src/services/plan-registration.ts
+++ b/frontend/src/services/plan-registration.ts
@@ -87,6 +87,7 @@ export async function registerCreditCard(params: {
   customerId: string
   userEmail: string
   planId?: string
+  campaignCode?: string
 }): Promise<CardRegisterResponse> {
   const requestBody: Record<string, string> = {
     customerId: params.customerId,
@@ -95,6 +96,10 @@ export async function registerCreditCard(params: {
 
   if (params.planId) {
     requestBody.planId = params.planId
+  }
+
+  if (params.campaignCode) {
+    requestBody.campaignCode = params.campaignCode
   }
 
   const response = await fetch('/api/payment/register', {


### PR DESCRIPTION
## ブランチについて
`feature/campaigns-base`ベース

## 概要

プラン登録画面にキャンペーンコード入力欄と適用中表示を追加し、カード登録完了画面にキャンペーン情報カードを表示する。
新規登録経由時のヘッダーも非表示に調整。

## 背景

- ユーザーが登録時にキャンペーンコードを入力できるようにする（validate API 呼び出しの UI）
- 決済完了後にキャンペーン適用情報を確認できる完了画面
- 新規登録経由のプラン登録画面ではヘッダーを非表示にして遷移を分かりやすくする


## 修正点

### 編集ファイル (3 commits)

| commit | 内容 |
|---|---|
| プラン登録画面にキャンペーンコード入力を統合 + 新規登録経由時の戻るボタン非表示 | validate API 呼び出しの入力欄 + 適用中状態表示 + 戻るボタン非表示ロジック |
| カード登録完了画面にキャンペーン情報カード表示（自動遷移停止） | 完了画面にキャンペーン情報カードを表示、自動遷移を停止 |
| 新規登録経由のプラン登録画面でヘッダー全体を非表示 | 登録経由フローでヘッダー全体を隠す |

## 関連

- 依存: feature/campaigns-base（BFF Route Handler）
- API 本体: tamanomi-api / feature/campaigns-user-api
- 後続 PR: プラン管理画面、ヘッダー判定切替