### PR TITLE
[追加開発③]　プラン管理画面にキャンペーン適用中表示を追加

### DIFF
--- a/frontend/src/components/molecules/PlanManagement.tsx
+++ b/frontend/src/components/molecules/PlanManagement.tsx
@@ -4,6 +4,7 @@ import { Crown, Settings } from "lucide-react"
 import { format } from "date-fns"
 import { ja } from "date-fns/locale"
 import type { Plan } from "../../types/user"
+import { formatJstYmd, computeFreePeriodEndYmd } from "@/lib/date-utils"
 
 export interface PlanManagementCampaignInfo {
   freeDaysApplied: number
@@ -19,18 +20,6 @@ interface PlanManagementProps {
   hasPaymentMethod?: boolean
   className?: string
   campaignInfo?: PlanManagementCampaignInfo | null
-}
-
-function formatJstYmd(iso: string): string {
-  const d = new Date(iso)
-  const jst = new Date(d.getTime() + 9 * 60 * 60 * 1000 - d.getTimezoneOffset() * 60 * 1000)
-  return `${jst.getUTCFullYear()}年${jst.getUTCMonth() + 1}月${jst.getUTCDate()}日`
-}
-
-function computeFreePeriodEnd(iso: string): string {
-  const d = new Date(iso)
-  d.setUTCDate(d.getUTCDate() - 1)
-  return formatJstYmd(d.toISOString())
 }
 
 export function PlanManagement({ plan, onChangePlan, onChangePaymentMethod, hasPaymentMethod: _hasPaymentMethod, className = "", campaignInfo }: PlanManagementProps) {
@@ -68,14 +57,14 @@ export function PlanManagement({ plan, onChangePlan, onChangePaymentMethod, hasP
                 </span>
                 <div className="flex items-baseline gap-1">
                   <span className="text-base font-semibold text-gray-500 line-through">
-                    ¥{plan.price.toLocaleString()}
+                    ¥{(plan.discountPrice ?? plan.price).toLocaleString()}
                   </span>
                   <span className="text-2xl font-bold text-[#4ca154]">¥0</span>
                 </div>
               </div>
               <div className="space-y-2">
                 <div className="space-y-2 text-xs text-green-900">
-                  <div>無料期間：{formatJstYmd(campaignInfo.appliedAt)}〜{computeFreePeriodEnd(campaignInfo.firstBillingDate)}</div>
+                  <div>無料期間：{formatJstYmd(campaignInfo.appliedAt)}〜{computeFreePeriodEndYmd(campaignInfo.firstBillingDate)}</div>
                   <div>初回決済日：{formatJstYmd(campaignInfo.firstBillingDate)}</div>
                 </div>
                 <p className="text-[8px] leading-relaxed text-gray-600">

--- a/frontend/src/components/molecules/PlanManagement.tsx
+++ b/frontend/src/components/molecules/PlanManagement.tsx
@@ -5,6 +5,12 @@ import { format } from "date-fns"
 import { ja } from "date-fns/locale"
 import type { Plan } from "../../types/user"
 
+export interface PlanManagementCampaignInfo {
+  freeDaysApplied: number
+  firstBillingDate: string
+  appliedAt: string
+}
+
 interface PlanManagementProps {
   plan: Plan
   onChangePlan: () => void
@@ -12,9 +18,22 @@ interface PlanManagementProps {
   onChangePaymentMethod?: () => void
   hasPaymentMethod?: boolean
   className?: string
+  campaignInfo?: PlanManagementCampaignInfo | null
 }
 
-export function PlanManagement({ plan, onChangePlan, onChangePaymentMethod, hasPaymentMethod: _hasPaymentMethod, className = "" }: PlanManagementProps) {
+function formatJstYmd(iso: string): string {
+  const d = new Date(iso)
+  const jst = new Date(d.getTime() + 9 * 60 * 60 * 1000 - d.getTimezoneOffset() * 60 * 1000)
+  return `${jst.getUTCFullYear()}年${jst.getUTCMonth() + 1}月${jst.getUTCDate()}日`
+}
+
+function computeFreePeriodEnd(iso: string): string {
+  const d = new Date(iso)
+  d.setUTCDate(d.getUTCDate() - 1)
+  return formatJstYmd(d.toISOString())
+}
+
+export function PlanManagement({ plan, onChangePlan, onChangePaymentMethod, hasPaymentMethod: _hasPaymentMethod, className = "", campaignInfo }: PlanManagementProps) {
   const formatDate = (date: Date) => {
     return format(date, "yyyy年M月d日", { locale: ja })
   }
@@ -36,27 +55,54 @@ export function PlanManagement({ plan, onChangePlan, onChangePaymentMethod, hasP
             </div>
             <h3 className="text-lg font-bold text-gray-900">現在のプラン</h3>
           </div>
-          
+
           <div className="text-sm text-gray-600 mb-4">サブスクリプション詳細</div>
 
           {/* プラン詳細 */}
-          <div className="bg-green-100 rounded-xl p-4">
-            <div className="text-center mb-3">
-              <h4 className="text-lg font-bold text-green-900">{plan.name}</h4>
-              <div className="text-2xl font-bold text-green-900">¥{(plan.discountPrice ?? plan.price).toLocaleString()}</div>
+          {campaignInfo ? (
+            <div className="bg-green-100 rounded-xl p-4 space-y-4">
+              <div className="flex flex-col items-center gap-2">
+                <h4 className="text-lg font-bold text-green-900">{plan.name}</h4>
+                <span className="rounded-full bg-[#4ca154] px-3 py-1 text-[10px] font-semibold text-white">
+                  キャンペーン適用中
+                </span>
+                <div className="flex items-baseline gap-1">
+                  <span className="text-base font-semibold text-gray-500 line-through">
+                    ¥{plan.price.toLocaleString()}
+                  </span>
+                  <span className="text-2xl font-bold text-[#4ca154]">¥0</span>
+                </div>
+              </div>
+              <div className="space-y-2">
+                <div className="space-y-2 text-xs text-green-900">
+                  <div>無料期間：{formatJstYmd(campaignInfo.appliedAt)}〜{computeFreePeriodEnd(campaignInfo.firstBillingDate)}</div>
+                  <div>初回決済日：{formatJstYmd(campaignInfo.firstBillingDate)}</div>
+                </div>
+                <p className="text-[8px] leading-relaxed text-gray-600">
+                  ※ プランを変更しても無料期間は継続します。<br />
+                  　初回決済日から、変更後プランの金額で継続課金を開始します
+                </p>
+              </div>
             </div>
-            
-            <div className="text-sm text-green-800 text-center mb-4">
-              {plan.description}
-            </div>
+          ) : (
+            <div className="bg-green-100 rounded-xl p-4">
+              <div className="text-center mb-3">
+                <h4 className="text-lg font-bold text-green-900">{plan.name}</h4>
+                <div className="text-2xl font-bold text-green-900">¥{(plan.discountPrice ?? plan.price).toLocaleString()}</div>
+              </div>
 
-            <div className="space-y-2 text-sm text-green-800">
-              <div>開始日：{formatDate(plan.startDate)}</div>
-              {plan.nextBillingDate && (
-                <div>次回請求日：{formatDate(plan.nextBillingDate)}</div>
-              )}
+              <div className="text-sm text-green-800 text-center mb-4">
+                {plan.description}
+              </div>
+
+              <div className="space-y-2 text-sm text-green-800">
+                <div>開始日：{formatDate(plan.startDate)}</div>
+                {plan.nextBillingDate && (
+                  <div>次回請求日：{formatDate(plan.nextBillingDate)}</div>
+                )}
+              </div>
             </div>
-          </div>
+          )}
         </div>
 
         {/* プラン変更セクション */}

--- a/frontend/src/components/organisms/PaymentReturnContainer.tsx
+++ b/frontend/src/components/organisms/PaymentReturnContainer.tsx
@@ -2,24 +2,13 @@
 
 import { useRouter } from 'next/navigation'
 import type { CampaignInfo } from '@/hooks/usePaymentReturn'
+import { formatJstDate, computeFreePeriodEnd } from '@/lib/date-utils'
 
 interface PaymentReturnContainerProps {
   isProcessing: boolean
   error: string | null
   isPaymentMethodChangeOnly: boolean
   campaignInfo?: CampaignInfo | null
-}
-
-function formatJstDate(iso: string): string {
-  const d = new Date(iso)
-  const jst = new Date(d.getTime() + 9 * 60 * 60 * 1000 - d.getTimezoneOffset() * 60 * 1000)
-  return `${jst.getUTCFullYear()}/${jst.getUTCMonth() + 1}/${jst.getUTCDate()}`
-}
-
-function computeFreePeriodEnd(firstBillingDateIso: string): string {
-  const d = new Date(firstBillingDateIso)
-  d.setUTCDate(d.getUTCDate() - 1)
-  return formatJstDate(d.toISOString())
 }
 
 export function PaymentReturnContainer({

--- a/frontend/src/components/organisms/PaymentReturnContainer.tsx
+++ b/frontend/src/components/organisms/PaymentReturnContainer.tsx
@@ -1,19 +1,38 @@
 "use client"
 
+import { useRouter } from 'next/navigation'
+import type { CampaignInfo } from '@/hooks/usePaymentReturn'
+
 interface PaymentReturnContainerProps {
   isProcessing: boolean
   error: string | null
   isPaymentMethodChangeOnly: boolean
+  campaignInfo?: CampaignInfo | null
+}
+
+function formatJstDate(iso: string): string {
+  const d = new Date(iso)
+  const jst = new Date(d.getTime() + 9 * 60 * 60 * 1000 - d.getTimezoneOffset() * 60 * 1000)
+  return `${jst.getUTCFullYear()}/${jst.getUTCMonth() + 1}/${jst.getUTCDate()}`
+}
+
+function computeFreePeriodEnd(firstBillingDateIso: string): string {
+  const d = new Date(firstBillingDateIso)
+  d.setUTCDate(d.getUTCDate() - 1)
+  return formatJstDate(d.toISOString())
 }
 
 export function PaymentReturnContainer({
   isProcessing,
   error,
   isPaymentMethodChangeOnly,
+  campaignInfo,
 }: PaymentReturnContainerProps) {
+  const router = useRouter()
+
   if (error) {
     const isUserNotFoundError = error.includes('アカウント登録が完了していない可能性があります')
-    
+
     return (
       <div className="min-h-screen bg-gradient-to-br from-green-50 to-green-100 flex items-center justify-center">
         <div className="bg-white p-8 rounded-lg shadow-md max-w-md w-full">
@@ -37,7 +56,7 @@ export function PaymentReturnContainer({
               エラーが発生しました
             </h2>
             <p className="text-gray-600 mb-6 whitespace-pre-line">{error}</p>
-            
+
             {isUserNotFoundError ? (
               <div className="space-y-3">
                 <p className="text-sm text-gray-500">
@@ -64,6 +83,63 @@ export function PaymentReturnContainer({
     )
   }
 
+  if (!isProcessing && campaignInfo) {
+    const freePeriodEnd = computeFreePeriodEnd(campaignInfo.firstBillingDate)
+    const firstBilling = formatJstDate(campaignInfo.firstBillingDate)
+
+    return (
+      <div className="min-h-screen bg-[#eefbf1] flex items-center justify-center px-4 py-10">
+        <div className="bg-white rounded-2xl shadow-[0px_4px_12px_rgba(0,0,0,0.25)] max-w-md w-full p-8 space-y-6">
+          <div className="flex justify-center">
+            <div className="h-[50px] w-[50px] rounded-full bg-[#049a2a] flex items-center justify-center">
+              <svg className="h-8 w-8 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
+              </svg>
+            </div>
+          </div>
+
+          <h2 className="text-center text-[22px] font-semibold text-black">カード登録完了</h2>
+
+          <div className="text-center text-sm text-[#3c4656] leading-[1.8]">
+            <p>ご登録ありがとうございます。</p>
+            <p>キャンペーンが適用されました。</p>
+          </div>
+
+          <div className="rounded-lg border border-[rgba(4,154,42,0.24)] bg-[#f0fdf4] px-4 py-6 space-y-4">
+            <p className="text-center text-xs font-bold text-[#33803f]">
+              最初の{campaignInfo.freeDaysApplied}日間無料 でご利用いただけます！
+            </p>
+            <div className="rounded-lg border border-[#d9d9d9] bg-white px-4 py-2">
+              <div className="flex items-center justify-between border-b border-[#d9d9d9] py-2">
+                <span className="text-xs text-[#757575]">無料期間</span>
+                <span className="flex items-center gap-1 text-xs font-bold text-[#33803f]">
+                  <span>本日</span>
+                  <span>〜</span>
+                  <span>{freePeriodEnd}</span>
+                </span>
+              </div>
+              <div className="flex items-center justify-between py-2">
+                <span className="text-xs text-[#757575]">初回決済日</span>
+                <span className="flex items-center gap-1 text-xs">
+                  <span className="font-medium text-black">{firstBilling}</span>
+                  <span className="font-bold text-[#757575]">(¥{campaignInfo.planPrice.toLocaleString()})</span>
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <button
+            type="button"
+            onClick={() => router.push('/home?payment-success=true')}
+            className="w-full rounded-2xl bg-[#049a2a] py-4 text-sm font-semibold text-white"
+          >
+            HOME画面へ進む
+          </button>
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-green-50 to-green-100 flex items-center justify-center">
       <div className="bg-white p-8 rounded-lg shadow-md max-w-md w-full">
@@ -77,8 +153,8 @@ export function PaymentReturnContainer({
                 {isPaymentMethodChangeOnly ? '支払い方法変更を処理中...' : 'カード登録を処理中...'}
               </h2>
               <p className="text-gray-600">
-                {isPaymentMethodChangeOnly 
-                  ? 'カード情報の変更を処理しています。\nしばらくお待ちください。' 
+                {isPaymentMethodChangeOnly
+                  ? 'カード情報の変更を処理しています。\nしばらくお待ちください。'
                   : 'カード情報の登録を処理しています。\nしばらくお待ちください。'
                 }
               </p>
@@ -104,8 +180,8 @@ export function PaymentReturnContainer({
                 {isPaymentMethodChangeOnly ? '支払い方法変更完了' : 'カード登録完了'}
               </h2>
               <p className="text-gray-600 mb-6">
-                {isPaymentMethodChangeOnly 
-                  ? 'カード情報の変更が完了しました。\nマイページに戻ります。' 
+                {isPaymentMethodChangeOnly
+                  ? 'カード情報の変更が完了しました。\nマイページに戻ります。'
                   : 'カード登録が完了しました。\nマイページに戻ります。'
                 }
               </p>
@@ -116,4 +192,3 @@ export function PaymentReturnContainer({
     </div>
   )
 }
-

--- a/frontend/src/components/templates/HomeLayout.tsx
+++ b/frontend/src/components/templates/HomeLayout.tsx
@@ -16,6 +16,7 @@ import { PlanManagementContainer
 
  } from "../organisms/PlanManagementContainer"
 import { PlanChangeContainer } from "../organisms/PlanChangeContainer"
+import { useCurrentCampaign } from "@/hooks/useCurrentCampaign"
 import { StoreIntroductionForm } from "../organisms/StoreIntroductionForm"
 import { CouponListPopup } from "../molecules/CouponListPopup"
 import { CouponUsedSuccessModal } from "../molecules/CouponUsedSuccessModal"
@@ -107,6 +108,7 @@ export function HomeLayout({ onMount }: HomeLayoutProps) {
   const lastSyncedStoresLengthRef = useRef(0)
   const currentView = navigation.currentView
   const myPageView = navigation.myPageView
+  const campaignInfo = useCurrentCampaign(myPageView === "plan-management")
   const isAuthenticated = auth.isAuthenticated
   const isLoading = auth.isLoading
   const signupData = state.signupData
@@ -847,6 +849,7 @@ export function HomeLayout({ onMount }: HomeLayoutProps) {
           onBack={() => onMyPageViewChange("main")}
           onLogoClick={onLogoClick}
           backgroundColorClass="bg-gradient-to-br from-green-50 to-green-100"
+          campaignInfo={campaignInfo}
         />
       )
     }

--- a/frontend/src/hooks/useCurrentCampaign.ts
+++ b/frontend/src/hooks/useCurrentCampaign.ts
@@ -1,0 +1,40 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import type { PlanManagementCampaignInfo } from "@/components/molecules/PlanManagement"
+
+export function useCurrentCampaign(enabled: boolean): PlanManagementCampaignInfo | null {
+  const [campaignInfo, setCampaignInfo] = useState<PlanManagementCampaignInfo | null>(null)
+
+  useEffect(() => {
+    if (!enabled) {
+      setCampaignInfo(null)
+      return
+    }
+    let cancelled = false
+    ;(async () => {
+      try {
+        const res = await fetch('/api/campaigns/me/current', { credentials: 'include' })
+        if (!res.ok) return
+        const data = await res.json()
+        if (cancelled) return
+        if (data?.hasActiveCampaign && data.application) {
+          setCampaignInfo({
+            freeDaysApplied: data.application.freeDaysApplied,
+            firstBillingDate: data.application.firstBillingDate,
+            appliedAt: data.application.appliedAt,
+          })
+        } else {
+          setCampaignInfo(null)
+        }
+      } catch {
+        return
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [enabled])
+
+  return campaignInfo
+}

--- a/frontend/src/lib/date-utils.ts
+++ b/frontend/src/lib/date-utils.ts
@@ -1,0 +1,33 @@
+const jstSlashDateFormatter = new Intl.DateTimeFormat('ja-JP', {
+  timeZone: 'Asia/Tokyo',
+  year: 'numeric',
+  month: 'numeric',
+  day: 'numeric',
+})
+
+const jstJapaneseDateFormatter = new Intl.DateTimeFormat('ja-JP', {
+  timeZone: 'Asia/Tokyo',
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+})
+
+export function formatJstDate(iso: string): string {
+  return jstSlashDateFormatter.format(new Date(iso))
+}
+
+export function formatJstYmd(iso: string): string {
+  return jstJapaneseDateFormatter.format(new Date(iso))
+}
+
+export function computeFreePeriodEnd(firstBillingDateIso: string): string {
+  const d = new Date(firstBillingDateIso)
+  d.setUTCDate(d.getUTCDate() - 1)
+  return formatJstDate(d.toISOString())
+}
+
+export function computeFreePeriodEndYmd(firstBillingDateIso: string): string {
+  const d = new Date(firstBillingDateIso)
+  d.setUTCDate(d.getUTCDate() - 1)
+  return formatJstYmd(d.toISOString())
+}


### PR DESCRIPTION
## ブランチについて
`feature/campaigns-registration`ベース

## 概要

プラン管理画面で現在適用中のキャンペーンを表示する機能を追加。/api/campaigns/me/current を fetch して、現在プラン枠にキャンペーン情報を反映する。

## 背景

- ユーザーが自身のプラン管理画面で「今キャンペーン適用中である」ことを確認できるようにする
- キャンペーン期間・残り日数・元プラン情報等を可視化

## 修正点

### 編集ファイル (2 commits)

| commit | 内容 |
|---|---|
| プラン管理画面にキャンペーン適用中の現在プラン表示追加 | 現在プラン枠にキャンペーン情報カードを追加（表示のみ、fetch は次コミットで実装） |
| プラン管理画面で /api/campaigns/me/current を fetch して適用中表示を反映 | useCurrentCampaign hook 経由で API 呼び出し、表示に反映 |

## 関連

- 依存: feature/campaigns-registration（プラン登録・完了画面）、feature/campaigns-base（BFF）
- API 本体: tamanomi-api / feature/campaigns-user-api
- 後続 PR: ヘッダー判定切替