### PR TITLE
[追加開発に伴う実装]　新規登録時のヘッダー非表示判定を account.status === 'pending' に切替

### DIFF
--- a/frontend/src/app/plan-registration/page.tsx
+++ b/frontend/src/app/plan-registration/page.tsx
@@ -12,6 +12,7 @@ export default function PlanRegistrationPage() {
     saitamaAppLinked,
     hasPaymentMethod,
     isPaymentMethodChangeOnly,
+    accountStatus,
     handlePaymentMethodRegister,
     handleSaitamaAppLinked,
     handleCancel,
@@ -42,6 +43,7 @@ export default function PlanRegistrationPage() {
       onSaitamaAppLinked={handleSaitamaAppLinked}
       hasPaymentMethod={hasPaymentMethod}
       isPaymentMethodChangeOnly={isPaymentMethodChangeOnly}
+      accountStatus={accountStatus}
     />
   )
 }

--- a/frontend/src/components/organisms/PlanRegistrationContainer.tsx
+++ b/frontend/src/components/organisms/PlanRegistrationContainer.tsx
@@ -17,6 +17,7 @@ interface PlanRegistrationContainerProps {
   onSaitamaAppLinked?: () => void
   hasPaymentMethod?: boolean
   isPaymentMethodChangeOnly?: boolean
+  accountStatus?: string | null
 }
 
 export function PlanRegistrationContainer({
@@ -31,11 +32,14 @@ export function PlanRegistrationContainer({
   onSaitamaAppLinked,
   hasPaymentMethod,
   isPaymentMethodChangeOnly,
+  accountStatus,
 }: PlanRegistrationContainerProps) {
+  const isPendingAccount = accountStatus === 'pending'
   return (
     <div className={`min-h-screen ${backgroundColorClass} flex flex-col`}>
-      {/* ヘッダー */}
-      <HeaderLogo onLogoClick={onLogoClick} showBackButton={true} onBackClick={onCancel} />
+      {!isPendingAccount && (
+        <HeaderLogo onLogoClick={onLogoClick} showBackButton={true} onBackClick={onCancel} />
+      )}
 
       {/* メインコンテンツ */}
       <div className="flex-1 flex items-center justify-center p-4">

--- a/frontend/src/hooks/usePlanRegistration.ts
+++ b/frontend/src/hooks/usePlanRegistration.ts
@@ -47,6 +47,7 @@ export function usePlanRegistration() {
   const [saitamaAppLinked, setSaitamaAppLinked] = useState<boolean | null>(null)
   const [hasPaymentMethod, setHasPaymentMethod] = useState<boolean>(false)
   const [isPaymentMethodChangeOnly, setIsPaymentMethodChangeOnly] = useState<boolean>(false)
+  const [accountStatus, setAccountStatus] = useState<string | null>(null)
   const [userId, setUserId] = useState<string>('')
   const router = useRouter()
 
@@ -74,6 +75,7 @@ export function usePlanRegistration() {
       }
 
       setSaitamaAppLinked(userData.saitamaAppLinked === true)
+      setAccountStatus(userData.status ?? null)
 
       const hasCard = userData.userCards && Array.isArray(userData.userCards) && userData.userCards.length > 0
       setHasPaymentMethod(!!hasCard)
@@ -397,6 +399,7 @@ export function usePlanRegistration() {
     saitamaAppLinked,
     hasPaymentMethod,
     isPaymentMethodChangeOnly,
+    accountStatus,
     handlePaymentMethodRegister,
     handleSaitamaAppLinked,
     handleCancel,

--- a/frontend/src/services/plan-registration.ts
+++ b/frontend/src/services/plan-registration.ts
@@ -7,6 +7,7 @@ import { ApiClient } from '@/lib/api-client'
 export interface UserData {
   id?: string
   email?: string
+  status?: string
   saitamaAppLinked?: boolean
   userCards?: unknown[]
   plan?: {


### PR DESCRIPTION
## 概要

新規登録経由のプラン登録画面でヘッダーを非表示にする判定を、URL パラメータではなく Account.status === 'pending' ベースに切り替える。

## 背景

- 従来は URL パラメータ（`?flow=signup` 等）でヘッダー非表示を判定していたが、URL 経由なので状態が失われやすかった
- Account.status に 'pending' が導入され、新規登録直後の状態が DB 側で明確に判別できるようになった
- Account.status を fetch して判定することで、URL パラメータ不要のよりロバストな判定に切り替える

## 修正点

### 編集ファイル (1 commit)

| commit | 内容 |
|---|---|
| 新規登録時のヘッダー非表示判定を account.status === 'pending' に切替 | usePlanRegistration hook で fetchCurrentUser 経由で status を取得、accountStatus === 'pending' で判定するよう変更。URL パラメータ ?flow=signup の依存を廃止 |

## 関連

- 依存: tamanomi-api / Phase 4（Account.status に pending 導入 + 認証・ログイン系で許容）
- 型定義: tamanomi-schemas
- 本 PR は Campaign 系（feature/campaigns-*）とは独立