### PR TITLE
有効キャンペーンが無い時はコード入力カードを非表示

### DIFF
--- a/frontend/src/app/api/campaigns/available/route.ts
+++ b/frontend/src/app/api/campaigns/available/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest } from 'next/server'
+import { buildApiUrl } from '@/lib/api-config'
+import { secureFetchWithCommonHeaders } from '@/lib/fetch-utils'
+import { createNoCacheResponse } from '@/lib/response-utils'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: NextRequest) {
+  try {
+    const fullUrl = buildApiUrl('/campaigns/available')
+
+    const response = await secureFetchWithCommonHeaders(request, fullUrl, {
+      method: 'GET',
+      headerOptions: {
+        requireAuth: true,
+      },
+    })
+
+    if (response.status === 401) {
+      return createNoCacheResponse({ error: '認証が必要です' }, { status: 401 })
+    }
+
+    const data = await response.json().catch(() => ({}))
+
+    if (!response.ok) {
+      console.error('❌ [campaigns/available] Backend API error:', data)
+      return createNoCacheResponse(
+        { error: data.message || data.error?.message || 'キャンペーン有無の取得に失敗しました' },
+        { status: response.status }
+      )
+    }
+
+    return createNoCacheResponse(data)
+  } catch (error) {
+    console.error('Campaigns available API fetch error:', error)
+    return createNoCacheResponse(
+      { error: 'キャンペーン有無の取得中にエラーが発生しました' },
+      { status: 500 }
+    )
+  }
+}

--- a/frontend/src/components/organisms/PlanRegistrationForm.tsx
+++ b/frontend/src/components/organisms/PlanRegistrationForm.tsx
@@ -12,6 +12,7 @@ import { FadeInComponent } from "@/components/atoms/ProgressiveLoader"
 import { PlanListResponse } from '@hv-development/schemas'
 import type { PaymentMethodType } from '@hv-development/schemas'
 import { ApiClient } from '@/lib/api-client';
+import { useCampaignAvailability } from '@/hooks/useCampaignAvailability'
 
 interface PlanRegistrationFormProps {
   onPaymentMethodRegister: (planId: string, paymentMethod: PaymentMethodType, campaignCode?: string) => void
@@ -80,6 +81,7 @@ export function PlanRegistrationForm({
   const [allPlansDisplayed, setAllPlansDisplayed] = useState(false)
   const [appliedCampaign, setAppliedCampaign] = useState<AppliedCampaign | null>(null)
   const displayedPlansCount = useRef(0)
+  const hasActiveCampaign = useCampaignAvailability(!isPaymentMethodChangeOnly)
 
   // 選択中のプランがサブスクリプションプランかを判定
   const selectedPlanData = plans.find(p => p.id === selectedPlan)
@@ -200,7 +202,7 @@ export function PlanRegistrationForm({
       )}
 
       {/* キャンペーンコード入力カード */}
-      {!isPaymentMethodChangeOnly && (
+      {!isPaymentMethodChangeOnly && hasActiveCampaign && (
         <CampaignCodeCard
           appliedCampaign={appliedCampaign}
           onApplied={setAppliedCampaign}

--- a/frontend/src/hooks/useCampaignAvailability.ts
+++ b/frontend/src/hooks/useCampaignAvailability.ts
@@ -1,0 +1,31 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+export function useCampaignAvailability(enabled: boolean): boolean {
+  const [hasActive, setHasActive] = useState<boolean>(false)
+
+  useEffect(() => {
+    if (!enabled) {
+      setHasActive(false)
+      return
+    }
+    let cancelled = false
+    ;(async () => {
+      try {
+        const res = await fetch('/api/campaigns/available', { credentials: 'include' })
+        if (!res.ok) return
+        const data = await res.json()
+        if (cancelled) return
+        setHasActive(data?.hasActive === true)
+      } catch {
+        return
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [enabled])
+
+  return hasActive
+}

--- a/frontend/src/hooks/useCampaignAvailability.ts
+++ b/frontend/src/hooks/useCampaignAvailability.ts
@@ -2,8 +2,12 @@
 
 import { useEffect, useState } from "react"
 
+// fail-open: API 失敗時は表示のまま。
+// キャンペーン開催中に誤って非表示にすると、コード入力欄が無いまま登録完走して
+// 無料期間なしで即時課金される (返金・問い合わせ対応の実害)。
+// 逆方向 (0 件なのに表示) の失敗コストはサーバー側 validate で弾かれるだけなので許容。
 export function useCampaignAvailability(enabled: boolean): boolean {
-  const [hasActive, setHasActive] = useState<boolean>(false)
+  const [hasActive, setHasActive] = useState<boolean>(true)
 
   useEffect(() => {
     if (!enabled) {
@@ -17,7 +21,7 @@ export function useCampaignAvailability(enabled: boolean): boolean {
         if (!res.ok) return
         const data = await res.json()
         if (cancelled) return
-        setHasActive(data?.hasActive === true)
+        setHasActive(data?.hasActive !== false)
       } catch {
         return
       }


### PR DESCRIPTION
## 概要
プラン登録画面 (`/plan-registration`) のキャンペーンコード入力カードを、アプリ内に有効なキャンペーンが 1 件以上ある場合のみ表示するように修正。

## 背景
テストシナリオ TC-U01-6「キャンペーンが1件も登録されていない場合、コード入力カードが表示されない」への対応。

Campaign テーブルが空 (対象 applicationId で有効キャンペーン 0 件) の場合、無効なコード入力を強いる UX になっていた。エラー表示は出さず、カードを単に非表示にする仕様。

## 仕様
| 状態 | 表示 |
|---|---|
| 有効キャンペーン 0 件 | コード入力カード非表示 (エラー表示なし) |
| 有効キャンペーン 1 件以上 | 従来通り表示 |
| 支払い方法変更モード (`?payment-method-change=true`) | 従来通り非表示 |

## 修正点
| ファイル | 変更内容 |
|---|---|
| 新規 `src/app/api/campaigns/available/route.ts` | BFF (tamanomi-api の `GET /campaigns/available` を代理呼び出し) |
| 新規 `src/hooks/useCampaignAvailability.ts` | BFF を叩いて `hasActive` を返す React hook |
| `src/components/organisms/PlanRegistrationForm.tsx` | 表示条件に `hasActiveCampaign` を追加 |

## 関連
- tamanomi-api PR # (`GET /campaigns/available` エンドポイント追加)
- nomoca-kagawa-web PR # (同機能の横展開)
- テストシナリオ TC-U01-6