### PR TITLE
適用済みボタンをdisable化しアプリ連携カードに¥0表示を反映

### DIFF
--- a/frontend/src/components/molecules/CampaignCodeCard.tsx
+++ b/frontend/src/components/molecules/CampaignCodeCard.tsx
@@ -14,7 +14,6 @@ export interface AppliedCampaign {
 interface CampaignCodeCardProps {
   appliedCampaign: AppliedCampaign | null
   onApplied: (campaign: AppliedCampaign) => void
-  onCleared: () => void
 }
 
 interface ValidateSuccessResponse {
@@ -33,7 +32,7 @@ type ValidateResponse = ValidateSuccessResponse | ValidateFailureResponse
 
 const CODE_PATTERN = /^[a-z0-9]{6,20}$/
 
-export function CampaignCodeCard({ appliedCampaign, onApplied, onCleared }: CampaignCodeCardProps) {
+export function CampaignCodeCard({ appliedCampaign, onApplied }: CampaignCodeCardProps) {
   const [code, setCode] = useState<string>("")
   const [errorMessage, setErrorMessage] = useState<string>("")
   const [isApplying, setIsApplying] = useState<boolean>(false)
@@ -96,12 +95,6 @@ export function CampaignCodeCard({ appliedCampaign, onApplied, onCleared }: Camp
     }
   }
 
-  const handleClear = () => {
-    setCode("")
-    setErrorMessage("")
-    onCleared()
-  }
-
   return (
     <div className="w-full rounded-2xl border border-[#d9d9d9] bg-white p-6 space-y-4">
       <div className="space-y-3">
@@ -145,8 +138,8 @@ export function CampaignCodeCard({ appliedCampaign, onApplied, onCleared }: Camp
           {isApplied ? (
             <button
               type="button"
-              onClick={handleClear}
-              className="shrink-0 rounded-lg border border-[#049a2a] bg-[#f0fdf4] px-2 py-3 text-sm font-semibold text-[#049a2a]"
+              disabled
+              className="shrink-0 cursor-not-allowed rounded-lg border border-[#049a2a] bg-[#f0fdf4] px-2 py-3 text-sm font-semibold text-[#049a2a]"
             >
               適用済み
             </button>

--- a/frontend/src/components/organisms/PlanRegistrationForm.tsx
+++ b/frontend/src/components/organisms/PlanRegistrationForm.tsx
@@ -206,7 +206,6 @@ export function PlanRegistrationForm({
         <CampaignCodeCard
           appliedCampaign={appliedCampaign}
           onApplied={setAppliedCampaign}
-          onCleared={() => setAppliedCampaign(null)}
         />
       )}
 
@@ -299,12 +298,30 @@ export function PlanRegistrationForm({
               </div>
               <div className="mb-3">
                 <div className="flex flex-col items-center">
-                  <span className="text-sm line-through text-gray-500 mb-1">
-                    ¥980/月
-                  </span>
-                  <p className="text-3xl font-bold text-blue-600 mb-1">
-                    ¥480/月
-                  </p>
+                  {appliedCampaign ? (
+                    <>
+                      <span className="text-sm line-through text-gray-500 mb-1">
+                        ¥480/月
+                      </span>
+                      <div className="flex items-end gap-1 mb-1">
+                        <p className="text-3xl font-bold text-blue-600 leading-none">
+                          ¥0
+                        </p>
+                        <p className="text-xs text-gray-500">
+                          /最初の{appliedCampaign.freeDays}日間
+                        </p>
+                      </div>
+                    </>
+                  ) : (
+                    <>
+                      <span className="text-sm line-through text-gray-500 mb-1">
+                        ¥980/月
+                      </span>
+                      <p className="text-3xl font-bold text-blue-600 mb-1">
+                        ¥480/月
+                      </p>
+                    </>
+                  )}
                   <p className="text-gray-700 text-sm font-medium">
                     さいたま市みんなのアプリ連携で
                   </p>


### PR DESCRIPTION
## 概要

TC-U02-1 で発覚したキャンペーンコード適用時の UI 不具合 2 件を修正。

## 背景

TC-U02-1（有効なキャンペーンコード適用時の表示確認）の期待値と実装の差異が 2 点判明。

| # | 事象 | 期待値 | 実際の挙動（Before） |
|---|---|---|---|
| 1 | 「適用済み」ボタンの押下 | 押下不可（disabled） | 押下すると適用済みコードがクリアされる |
| 2 | 「さらにお得に！」アプリ連携カードの価格表示 | キャンペーン適用時は ¥0 /最初のN日間 に切り替わる | 常に ¥980 打ち消し + ¥480/月 のハードコード表示 |

## 仕様

### CampaignCodeCard

| 状態 | ボタン | 押下時の挙動 |
|---|---|---|
| 未適用 | 「適用する」（活性） | コード検証 → 成功時に適用 |
| 適用済み | 「適用済み」（disabled） | 反応なし（cursor-not-allowed） |

適用済みコードは画面内で取り消し不可。誤入力時は画面遷移/リロードで対応。

### アプリ連携カード（PlanRegistrationForm 内）

| キャンペーン状態 | 打ち消し価格 | 大表示価格 |
|---|---|---|
| 未適用 | ¥980/月 | ¥480/月 |
| 適用済み | ¥480/月 | ¥0 /最初のN日間 |

N は `appliedCampaign.freeDays`（管理画面で設定される無料日数）から動的取得。

## 修正点

| ファイル | 内容 |
|---|---|
| `components/molecules/CampaignCodeCard.tsx` | 適用済みボタンから `onClick={handleClear}` を削除し `disabled` 化。未使用となった `handleClear` 関数と `onCleared` prop を削除 |
| `components/organisms/PlanRegistrationForm.tsx` | `<CampaignCodeCard>` の `onCleared` 受け渡しを削除。アプリ連携カードの価格表示を `appliedCampaign` の有無で分岐 |

## 関連

- テストケース: TC-U02-1（プラン登録画面 / 新規会員登録後にキャンペーンコード適用）
- ローカル動作確認済み
- issue https://github.com/HV-development/tamanomi-api/issues/418