### PR TITLE
useCampaignAvailability の res.json() に CampaignAvailabilityResponse 型を付与 (#415)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
-    "@hv-development/schemas": "1.140.0",
+    "@hv-development/schemas": "1.141.0",
     "@radix-ui/react-accordion": "1.2.2",
     "@radix-ui/react-alert-dialog": "1.1.4",
     "@radix-ui/react-aspect-ratio": "1.1.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -13,8 +13,8 @@ dependencies:
     specifier: ^3.10.0
     version: 3.10.0(react-hook-form@7.68.0)
   '@hv-development/schemas':
-    specifier: 1.140.0
-    version: 1.140.0
+    specifier: 1.141.0
+    version: 1.141.0
   '@radix-ui/react-accordion':
     specifier: 1.2.2
     version: 1.2.2(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1)
@@ -579,8 +579,8 @@ packages:
     deprecated: Use @eslint/object-schema instead
     dev: true
 
-  /@hv-development/schemas@1.140.0:
-    resolution: {integrity: sha512-zx17/5cnDPPLECNz9zD/yhbnjBfJL4JzYjnYRF6oKJ18s1o04mwqMs93TBOuyRPL6ys273KH5qutHzgHs/FVpw==, tarball: https://npm.pkg.github.com/download/@hv-development/schemas/1.140.0/5f957f0e5cb7adb5eb50290eaba027e5d09dde9d}
+  /@hv-development/schemas@1.141.0:
+    resolution: {integrity: sha512-WnkeITAGPJBOcz7gtHff0AXt8HAyFzpWcaeBWItBHVm/nHxbxxYvmQNVzJK/N+Xw+ISonaD5wpmNGhZ/7DvN8A==, tarball: https://npm.pkg.github.com/download/@hv-development/schemas/1.141.0/1f534cc4d8a1c9b85984dadc878328fbfed088cb}
     engines: {node: 22.x}
     dependencies:
       zod: 3.25.76

--- a/frontend/src/hooks/useCampaignAvailability.ts
+++ b/frontend/src/hooks/useCampaignAvailability.ts
@@ -1,6 +1,7 @@
 "use client"
 
 import { useEffect, useState } from "react"
+import type { CampaignAvailabilityResponse } from "@hv-development/schemas"
 
 // fail-open: API 失敗時は表示のまま。
 // キャンペーン開催中に誤って非表示にすると、コード入力欄が無いまま登録完走して
@@ -19,9 +20,9 @@ export function useCampaignAvailability(enabled: boolean): boolean {
       try {
         const res = await fetch('/api/campaigns/available', { credentials: 'include' })
         if (!res.ok) return
-        const data = await res.json()
+        const data = (await res.json()) as CampaignAvailabilityResponse
         if (cancelled) return
-        setHasActive(data?.hasActive !== false)
+        setHasActive(data.hasActive !== false)
       } catch {
         return
       }


### PR DESCRIPTION
## 概要

\`useCampaignAvailability\` hook で \`fetch('/api/campaigns/available')\` のレスポンスを \`@hv-development/schemas\` の \`CampaignAvailabilityResponse\` として型付きで参照するように変更。合わせて schemas を 1.141.0 に追従。

## 背景

Issue #415 対応。tamanomi-schemas 1.141.0 で追加された型を利用。従来は \`const data = await res.json()\` で any 扱いだったため、API 側のフィールド名が変わっても tsc で検知できず、silent に \`false\` に落ちて CampaignCodeCard が全ユーザーで非表示になるリスクがあった。

## 修正点

| ファイル | 変更 |
|---|---|
| \`frontend/src/hooks/useCampaignAvailability.ts\` | \`CampaignAvailabilityResponse\` を型 import、\`res.json()\` の結果に \`as CampaignAvailabilityResponse\` を付与、\`data?.hasActive\` → \`data.hasActive\` |
| \`frontend/package.json\` | \`@hv-development/schemas\` を 1.140.0 → 1.141.0 |
| \`frontend/pnpm-lock.yaml\` | 同上 |

**fail-open 挙動 (API 失敗時は表示のまま) は維持**。CampaignCodeCard が誤って非表示になる方が実害が大きい（無料期間なしで即時課金）ため。

## 動作確認

- \`pnpm tsc --noEmit\` エラーなし
- \`pnpm dev\` 起動後、\`/plan-registration\` で DevTools Network で \`GET /api/campaigns/available\` が \`{"hasActive": true|false}\` を返すこと
- キャンペーン開催中: CampaignCodeCard 表示
- キャンペーン未開催: CampaignCodeCard 非表示
- API 失敗: CampaignCodeCard 表示 (fail-open)

## 関連

- Issue: https://github.com/HV-development/tamanomi-api/issues/415
- schemas PR: (マージ済み・publish 済み)
- tamanomi-api PR (別途)
- nomoca-kagawa-web PR (別途、同一の変更)