### PR TITLE
chore(deps): bump @hv-development/schemas to 1.142.0

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
-    "@hv-development/schemas": "1.141.0",
+    "@hv-development/schemas": "1.142.0",
     "@radix-ui/react-accordion": "1.2.2",
     "@radix-ui/react-alert-dialog": "1.1.4",
     "@radix-ui/react-aspect-ratio": "1.1.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -13,8 +13,8 @@ dependencies:
     specifier: ^3.10.0
     version: 3.10.0(react-hook-form@7.68.0)
   '@hv-development/schemas':
-    specifier: 1.141.0
-    version: 1.141.0
+    specifier: 1.142.0
+    version: 1.142.0
   '@radix-ui/react-accordion':
     specifier: 1.2.2
     version: 1.2.2(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1)
@@ -235,24 +235,24 @@ packages:
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
     engines: {node: '>=6.9.0'}
 
-  /@emnapi/core@1.11.2:
-    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
+  /@emnapi/core@1.11.3:
+    resolution: {integrity: sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==}
     requiresBuild: true
     dependencies:
-      '@emnapi/wasi-threads': 1.2.2
+      '@emnapi/wasi-threads': 1.2.3
       tslib: 2.8.1
     dev: true
     optional: true
 
-  /@emnapi/runtime@1.11.2:
-    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
+  /@emnapi/runtime@1.11.3:
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
     requiresBuild: true
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  /@emnapi/wasi-threads@1.2.2:
-    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+  /@emnapi/wasi-threads@1.2.3:
+    resolution: {integrity: sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==}
     requiresBuild: true
     dependencies:
       tslib: 2.8.1
@@ -579,8 +579,8 @@ packages:
     deprecated: Use @eslint/object-schema instead
     dev: true
 
-  /@hv-development/schemas@1.141.0:
-    resolution: {integrity: sha512-WnkeITAGPJBOcz7gtHff0AXt8HAyFzpWcaeBWItBHVm/nHxbxxYvmQNVzJK/N+Xw+ISonaD5wpmNGhZ/7DvN8A==, tarball: https://npm.pkg.github.com/download/@hv-development/schemas/1.141.0/1f534cc4d8a1c9b85984dadc878328fbfed088cb}
+  /@hv-development/schemas@1.142.0:
+    resolution: {integrity: sha512-sK1dgt9cGqyKeXqCgKdiXAF+2axvU/vkwkZBgDMleKomO4W9QzHXhrdCjAfE89ogESd5n0T8Zu1fB00snC7Ygg==, tarball: https://npm.pkg.github.com/download/@hv-development/schemas/1.142.0/5d7ed5209ff320bc8303675ce1b860d885b8d9c2}
     engines: {node: 22.x}
     dependencies:
       zod: 3.25.76
@@ -767,7 +767,7 @@ packages:
     cpu: [wasm32]
     requiresBuild: true
     dependencies:
-      '@emnapi/runtime': 1.11.2
+      '@emnapi/runtime': 1.11.3
     optional: true
 
   /@img/sharp-win32-arm64@0.34.5:
@@ -829,8 +829,8 @@ packages:
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
     requiresBuild: true
     dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
       '@tybys/wasm-util': 0.10.3
     dev: true
     optional: true


### PR DESCRIPTION
## 概要

`@hv-development/schemas` を 1.141.0 → 1.142.0 に更新します。

## 背景

tamanomi-schemas 1.142.0 で管理画面キャンペーン新規登録用のスキーマ (`campaignCheckCodeQuerySchema` 等) が追加されました（[HV-development/tamanomi-api#432](https://github.com/HV-development/tamanomi-api/issues/432) 対応）。tamanomi-web 本体には該当スキーマの直接利用箇所はありませんが、consumer リポ間で `@hv-development/schemas` のバージョンを揃える方針のため追随します。

## 修正点

| ファイル | 変更内容 |
|---|---|
| `frontend/package.json` | `@hv-development/schemas`: `1.141.0` → `1.142.0` |
| `frontend/pnpm-lock.yaml` | lockfile 追随 |

## 関連

- 元となる版上げ: HV-development/tamanomi-schemas#? (chore: bump version to 1.142.0)
- 追加スキーマの用途 Issue: HV-development/tamanomi-api#432