### PR TITLE
[Fix] pending ユーザーの離脱導線ガード追加 (#422)

### DIFF
--- a/frontend/src/hooks/usePlanRegistration.ts
+++ b/frontend/src/hooks/usePlanRegistration.ts
@@ -132,6 +132,19 @@ export function usePlanRegistration() {
     return () => window.removeEventListener('focus', handleFocus)
   }, [email, refreshUserInfo])
 
+  // pending ユーザーが /plan-registration からブラウザバックで離脱するのを防ぐ
+  useEffect(() => {
+    if (!isClient || accountStatus !== 'pending') return
+    if (typeof window === 'undefined') return
+
+    window.history.pushState(null, '', window.location.href)
+    const handlePopState = () => {
+      window.history.pushState(null, '', window.location.href)
+    }
+    window.addEventListener('popstate', handlePopState)
+    return () => window.removeEventListener('popstate', handlePopState)
+  }, [isClient, accountStatus])
+
   // --- saitamaAppLinked 未確定時にユーザー情報取得 ---
   useEffect(() => {
     if (isClient && saitamaAppLinked === null) {

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -157,6 +157,13 @@ export async function middleware(request: NextRequest) {
     return response;
   }
 
+  const hasAccessToken =
+    request.cookies.get(COOKIE_NAMES.ACCESS_TOKEN)?.value ||
+    request.cookies.get(COOKIE_NAMES.HOST_ACCESS_TOKEN)?.value
+  const hasRefreshToken =
+    request.cookies.get(COOKIE_NAMES.REFRESH_TOKEN)?.value ||
+    request.cookies.get(COOKIE_NAMES.HOST_REFRESH_TOKEN)?.value
+
   // アプリの保護ページはCookieが無ければログインへ
   const protectedPaths = [
     '/home',
@@ -165,27 +172,46 @@ export async function middleware(request: NextRequest) {
     '/payment-method-change',
     '/usage-guide',
   ]
+  const isProtected = protectedPaths.some(p => pathname === p || pathname.startsWith(`${p}/`))
 
-  if (protectedPaths.some(p => pathname === p || pathname.startsWith(`${p}/`))) {
-    const hasAccessToken =
-      request.cookies.get(COOKIE_NAMES.ACCESS_TOKEN)?.value ||
-      request.cookies.get(COOKIE_NAMES.HOST_ACCESS_TOKEN)?.value
-    const hasRefreshToken =
-      request.cookies.get(COOKIE_NAMES.REFRESH_TOKEN)?.value ||
-      request.cookies.get(COOKIE_NAMES.HOST_REFRESH_TOKEN)?.value
+  if (isProtected && !hasAccessToken && !hasRefreshToken) {
+    const url = request.nextUrl.clone()
+    url.pathname = '/login'
+    url.searchParams.set('session', 'expired')
+    const redirectResponse = NextResponse.redirect(url)
+    redirectResponse.headers.set('Cache-Control', 'no-store, no-cache, must-revalidate, private')
+    redirectResponse.headers.set('Pragma', 'no-cache')
+    redirectResponse.headers.set('Expires', '0')
+    return redirectResponse
+  }
 
-    if (!hasAccessToken && !hasRefreshToken) {
-      const url = request.nextUrl.clone()
-      url.pathname = '/login'
-      url.searchParams.set('session', 'expired')
-      const redirectResponse = NextResponse.redirect(url)
-      redirectResponse.headers.set('Cache-Control', 'no-store, no-cache, must-revalidate, private')
-      redirectResponse.headers.set('Pragma', 'no-cache')
-      redirectResponse.headers.set('Expires', '0')
-      return redirectResponse
+  const pendingGuardedPaths = ['/', '/home', '/mypage', '/payment-method-change', '/usage-guide']
+  const isPendingGuarded = pendingGuardedPaths.some(p =>
+    pathname === p || (p !== '/' && pathname.startsWith(`${p}/`))
+  )
+  if (isPendingGuarded && (hasAccessToken || hasRefreshToken)) {
+    try {
+      const meUrl = new URL('/api/user/me', request.nextUrl.origin)
+      const meResponse = await fetch(meUrl, {
+        headers: { cookie: request.headers.get('cookie') ?? '' },
+        cache: 'no-store',
+      })
+      if (meResponse.ok) {
+        const me = (await meResponse.json()) as { accountStatus?: string }
+        if (me.accountStatus === 'pending') {
+          const url = request.nextUrl.clone()
+          url.pathname = '/plan-registration'
+          url.search = ''
+          const redirectResponse = NextResponse.redirect(url)
+          redirectResponse.headers.set('Cache-Control', 'no-store, no-cache, must-revalidate, private')
+          redirectResponse.headers.set('Pragma', 'no-cache')
+          redirectResponse.headers.set('Expires', '0')
+          return redirectResponse
+        }
+      }
+    } catch (err) {
+      console.warn('[middleware] pending guard fetch failed', err)
     }
-    // 署名検証・リフレッシュはAPI層（authenticatedFetch）で実施。
-    // ここではいずれかのトークンCookieが存在すれば通過させる。
   }
 
   const response = NextResponse.next()


### PR DESCRIPTION
## 概要

`Account.status = pending` のユーザーが保護ページに直アクセスできてしまう不具合を修正。

## 背景

Issue #422 で報告された TC-U11-2 / TC-U11-4 / TC-U11-5 の実測不具合。

- `/home`, `/mypage`, `/usage-guide`, `/payment-method-change` に直アクセスするとページ内容が表示されてしまう
- `/plan-registration` からブラウザバックで `/email-registration` に離脱できてしまう
- Rina さんの追加要件として `/`（店舗一覧）も pending ガード対象に含める

## 仕様

| パス | 未ログイン | ログイン済 active | ログイン済 pending |
|---|---|---|---|
| `/` | 通常表示 | 通常表示 | `/plan-registration` へ |
| `/home` | `/login` へ | 通常表示 | `/plan-registration` へ |
| `/mypage` | `/login` へ | 通常表示 | `/plan-registration` へ |
| `/usage-guide` | `/login` へ | 通常表示 | `/plan-registration` へ |
| `/payment-method-change` | `/login` へ | 通常表示 | `/plan-registration` へ |
| `/plan-registration` | `/login` へ | 通常表示 | 通常表示 + ブラウザバック封じ |

## 修正点

- `src/middleware.ts`
  - Cookie 取得を関数冒頭に出し、Cookie 判定と pending 判定を分離してリファクタ
  - `pendingGuardedPaths` を新設し、対象パスにログイン済みでアクセスされた際に `/api/user/me` を叩いて `accountStatus === 'pending'` なら `/plan-registration` へリダイレクト
  - `/api/user/me` の失敗（401/500/例外）はサイレント通過（既存の useAuth 側でハンドリング）
- `src/hooks/usePlanRegistration.ts`
  - pending ユーザー限定で `history.pushState` + `popstate` リスナーによりブラウザバックを封じる
  - アンマウント時にリスナー解除、他ステータスでは既存挙動維持

## 関連

- Refs: HV-development/tamanomi-api#422（起票先。修正は tamanomi-web + nomoca-kagawa-web の 2 本）
- ミラー PR: nomoca-kagawa-web の同名ブランチ（tamanomi-web PR 側でリンク）