### PR TITLE
[Fix] キャンペーン適用中ユーザーの退会確認画面に無料期間終了・1年間再適用不可の警告を追加 (#427)

### DIFF
--- a/frontend/src/components/molecules/WithdrawalConfirmation.tsx
+++ b/frontend/src/components/molecules/WithdrawalConfirmation.tsx
@@ -3,14 +3,16 @@
 import { useState } from "react"
 import { AlertTriangle } from "lucide-react"
 import { Button } from "@/components/atoms/Button"
+import type { PlanManagementCampaignInfo } from "@/components/molecules/PlanManagement"
 
 interface WithdrawalConfirmationProps {
   onConfirm: () => void | Promise<void>
   onCancel: () => void
   isLoading?: boolean
+  campaignInfo?: PlanManagementCampaignInfo | null
 }
 
-export function WithdrawalConfirmation({ onConfirm, onCancel, isLoading = false }: WithdrawalConfirmationProps) {
+export function WithdrawalConfirmation({ onConfirm, onCancel, isLoading = false, campaignInfo = null }: WithdrawalConfirmationProps) {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const disabled = isLoading || isSubmitting
 
@@ -52,8 +54,15 @@ export function WithdrawalConfirmation({ onConfirm, onCancel, isLoading = false 
             <div className="font-bold text-red-900 mb-2">重要なご注意事項</div>
             <ul className="space-y-2">
               <li>1. 退会後にデータを復旧することはできません。再度ご利用いただく場合は、新規登録が必要となります。</li>
-              <li>2. 退会手続き後も、ご契約期間の終了日まではサービスをご利用いただけます。</li>
+              {campaignInfo ? (
+                <li>2. 退会手続き後は、キャンペーンの無料期間は終了し、サービスをご利用いただけません。</li>
+              ) : (
+                <li>2. 退会手続き後も、ご契約期間の終了日まではサービスをご利用いただけます。</li>
+              )}
               <li>3. 契約期間終了後は自動的にアカウントが無効になります。</li>
+              {campaignInfo && (
+                <li>4. 退会手続き後も、約1年間は無料キャンペーンが適用されません。</li>
+              )}
             </ul>
           </div>
         </div>

--- a/frontend/src/components/organisms/MypageContainer.tsx
+++ b/frontend/src/components/organisms/MypageContainer.tsx
@@ -8,6 +8,7 @@ import { Logo } from "../atoms/Logo"
 import { getNextRankInfo, getMonthsToNextRank, RANK_INFO } from "@/utils/rank-calculator"
 import { WithdrawalComplete } from "@/components/molecules/WithdrawalComplete"
 import { WithdrawalFailed } from "@/components/molecules/WithdrawalFailed"
+import type { PlanManagementCampaignInfo } from "@/components/molecules/PlanManagement"
 import type { User as UserType, Plan, UsageHistory, PaymentHistory } from "@/types/user"
 import { appConfig } from '@/config/appConfig'
 import { SkeletonMyPage } from "../skeletons/MypageSkeleton"
@@ -70,6 +71,7 @@ interface MyPageContainerProps {
   newEmail?: string
   currentUserRank?: string | null
   isEmailChangeSuccessModalOpen?: boolean
+  campaignInfo?: PlanManagementCampaignInfo | null
 }
 
 // ランク計算用のカスタムフック
@@ -453,6 +455,7 @@ export const MyPageContainer = React.memo(function MyPageContainer({
   newEmail = "",
   currentUserRank,
   isEmailChangeSuccessModalOpen = false,
+  campaignInfo = null,
 }: MyPageContainerProps) {
   // 背景色をメモ化
   const backgroundColorClass = useMemo(() =>
@@ -495,6 +498,7 @@ export const MyPageContainer = React.memo(function MyPageContainer({
       passwordChangeError={passwordChangeError}
       newEmail={newEmail}
       currentUserRank={currentUserRank}
+      campaignInfo={campaignInfo}
     />
   }
 
@@ -576,7 +580,8 @@ const MyPageSubView = React.memo(({
   passwordChangeStep,
   passwordChangeError,
   newEmail,
-  currentUserRank
+  currentUserRank,
+  campaignInfo
 }: {
   currentView: string
   user?: UserType
@@ -599,6 +604,7 @@ const MyPageSubView = React.memo(({
   passwordChangeError: string | null
   newEmail: string
   currentUserRank: string | null | undefined
+  campaignInfo?: PlanManagementCampaignInfo | null
 }) => {
   switch (currentView) {
     case "profile-edit":
@@ -683,6 +689,7 @@ const MyPageSubView = React.memo(({
             onLogoClick={onLogoClick}
             isLoading={false}
             backgroundColorClass="bg-gradient-to-br from-green-50 to-green-100"
+            campaignInfo={campaignInfo}
           />
         </LazyFallback>
       )

--- a/frontend/src/components/organisms/WithdrawalContainer.tsx
+++ b/frontend/src/components/organisms/WithdrawalContainer.tsx
@@ -2,6 +2,7 @@
 
 import { HeaderLogo } from "../atoms/HeaderLogo"
 import { WithdrawalConfirmation } from "@/components/molecules/WithdrawalConfirmation"
+import type { PlanManagementCampaignInfo } from "@/components/molecules/PlanManagement"
 
 interface WithdrawalContainerProps {
   onWithdraw: () => void
@@ -10,9 +11,10 @@ interface WithdrawalContainerProps {
   onLogoClick: () => void
   isLoading?: boolean
   backgroundColorClass?: string
+  campaignInfo?: PlanManagementCampaignInfo | null
 }
 
-export function WithdrawalContainer({ onWithdraw, onWithdrawCancel, onLogoClick, isLoading, backgroundColorClass = "bg-gradient-to-br from-green-50 to-green-100" }: WithdrawalContainerProps) {
+export function WithdrawalContainer({ onWithdraw, onWithdrawCancel, onLogoClick, isLoading, backgroundColorClass = "bg-gradient-to-br from-green-50 to-green-100", campaignInfo = null }: WithdrawalContainerProps) {
   return (
     <div className={`min-h-screen ${backgroundColorClass} flex flex-col`}>
       {/* ヘッダー */}
@@ -21,7 +23,7 @@ export function WithdrawalContainer({ onWithdraw, onWithdrawCancel, onLogoClick,
       {/* メインコンテンツ */}
       <div className="flex-1 flex items-center justify-center p-4">
         <div className="w-full max-w-md">
-          <WithdrawalConfirmation onConfirm={onWithdraw} onCancel={onWithdrawCancel} isLoading={isLoading} />
+          <WithdrawalConfirmation onConfirm={onWithdraw} onCancel={onWithdrawCancel} isLoading={isLoading} campaignInfo={campaignInfo} />
         </div>
       </div>
     </div>

--- a/frontend/src/components/templates/HomeLayout.tsx
+++ b/frontend/src/components/templates/HomeLayout.tsx
@@ -108,7 +108,10 @@ export function HomeLayout({ onMount }: HomeLayoutProps) {
   const lastSyncedStoresLengthRef = useRef(0)
   const currentView = navigation.currentView
   const myPageView = navigation.myPageView
-  const campaignInfo = useCurrentCampaign(myPageView === "plan-management")
+  const campaignInfo = useCurrentCampaign(
+    myPageView === "plan-management" ||
+    myPageView === "withdrawal"
+  )
   const isAuthenticated = auth.isAuthenticated
   const isLoading = auth.isLoading
   const signupData = state.signupData
@@ -905,6 +908,7 @@ export function HomeLayout({ onMount }: HomeLayoutProps) {
         newEmail={newEmail}
         currentUserRank={currentUserRank}
         isEmailChangeSuccessModalOpen={isEmailChangeSuccessModalOpen}
+        campaignInfo={campaignInfo}
       />
     )
   }

--- a/frontend/src/components/templates/MypageLayout.tsx
+++ b/frontend/src/components/templates/MypageLayout.tsx
@@ -1,6 +1,7 @@
 import { MyPageContainer } from "../organisms/MypageContainer"
 import type { User, Plan, UsageHistory, PaymentHistory } from "@/types/user"
 import type { ProfileEditFormData } from "@/types/forms"
+import type { PlanManagementCampaignInfo } from "@/components/molecules/PlanManagement"
 
 interface MyPageLayoutProps {
   user?: User
@@ -50,6 +51,7 @@ interface MyPageLayoutProps {
   newEmail?: string
   currentUserRank?: string | null
   isEmailChangeSuccessModalOpen?: boolean
+  campaignInfo?: PlanManagementCampaignInfo | null
 }
 
 export function MyPageLayout({
@@ -89,6 +91,7 @@ export function MyPageLayout({
   currentUserRank,
   isEmailChangeSuccessModalOpen,
   hasStoreIntroduction,
+  campaignInfo,
 }: MyPageLayoutProps) {
   return (
     <MyPageContainer
@@ -128,6 +131,7 @@ export function MyPageLayout({
       newEmail={newEmail}
       currentUserRank={currentUserRank}
       isEmailChangeSuccessModalOpen={isEmailChangeSuccessModalOpen}
+      campaignInfo={campaignInfo}
     />
   )
 }


### PR DESCRIPTION
## 概要

キャンペーン適用中（無料期間中）のユーザーが退会確認画面に進んだ際、無料期間中特有の警告文言が表示されていなかった問題を修正する。

## 背景

Issue #427 で報告された不具合。TC-U13-1 のテスト観点で、キャンペーン適用ユーザーが自主解約フローに進んだ場合の警告表示が仕様通り出ていなかった。

| 項目 | 内容 |
|---|---|
| 対象 Issue | #427 |
| 対象 TC | TC-U13-1（+ TC-U12-12 文言部分） |
| 影響範囲 | 退会確認画面（キャンペーン適用中ユーザーのみ） |

## 仕様

退会確認画面「重要なご注意事項」の赤枠リストを、キャンペーン適用状態に応じて出し分ける。

| 項目 | 通常ユーザー（従来） | キャンペーン適用ユーザー（本 PR で追加） |
|---|---|---|
| 1 | 退会後にデータを復旧することはできません。〜 | 同左 |
| 2 | 退会手続き後も、ご契約期間の終了日まではサービスをご利用いただけます。 | **退会手続き後は、キャンペーンの無料期間は終了し、サービスをご利用いただけません。** |
| 3 | 契約期間終了後は自動的にアカウントが無効になります。 | 同左 |
| 4 | （なし） | **退会手続き後も、約1年間は無料キャンペーンが適用されません。** |

キャンペーン適用状態の判定は既存の `useCurrentCampaign` フック（`GET /api/campaigns/me/current`）を流用。

## 修正点

| ファイル | 変更内容 |
|---|---|
| `frontend/src/components/templates/HomeLayout.tsx` | `useCurrentCampaign` の enable 条件に `withdrawal` view を追加、`<MyPageLayout>` に `campaignInfo` を渡す |
| `frontend/src/components/templates/MypageLayout.tsx` | props に `campaignInfo` を追加、`MyPageContainer` へ pass-through |
| `frontend/src/components/organisms/MypageContainer.tsx` | props に `campaignInfo` を追加、`MyPageSubView` 経由で `WithdrawalContainer` へ注入 |
| `frontend/src/components/organisms/WithdrawalContainer.tsx` | props に `campaignInfo` を追加、`WithdrawalConfirmation` へ pass |
| `frontend/src/components/molecules/WithdrawalConfirmation.tsx` | 赤枠リストの項目 2 を差し替え + 項目 4 を条件付きで追加 |

`WithdrawalComplete.tsx`（退会完了画面）は本 PR のスコープ外。

## 動作確認

| ケース | 期待挙動 |
|---|---|
| キャンペーン非適用ユーザーの退会確認画面 | 赤枠リストが 3 項目（従来通り） |
| キャンペーン適用ユーザーの退会確認画面 | 赤枠リストが 4 項目、項目 2 が「無料期間終了・利用不可」に変わる |

## 関連

- Issue: https://github.com/HV-development/tamanomi-api/issues/427
- 関連 Issue: 「UCA 未作成」Issue（本修正が正しく動くには UCA が active である必要あり）
- ペア PR: nomoca-kagawa-web #<番号>（両ブランド同一仕様のため同時マージ推奨）