### PR TITLE
fix: payment/register BFF の未定義関数呼び出しを修正（PR #279 マージ起因の500エラー）

### DIFF
--- a/frontend/src/app/api/payment/register/route.ts
+++ b/frontend/src/app/api/payment/register/route.ts
@@ -45,7 +45,7 @@ export async function POST(request: NextRequest) {
       backendRequestBody.campaignCode = trimmedCampaignCode
     }
 
-    const response = await secureFetchWithCommonHeaders(request, fullUrl, {
+    const { response } = await authenticatedFetch(request, fullUrl, {
       method: 'POST',
       headerOptions: {
         requireAuth: true,


### PR DESCRIPTION
## Summary
- PR #279 のマージコミット（e7d0659 のコンフリクト解消）で `frontend/src/app/api/payment/register/route.ts` の import は `authenticatedFetch` に差し替わった一方、呼び出し箇所が旧関数 `secureFetchWithCommonHeaders` のまま残っていた
- このため POST `/api/payment/register` は全リクエストで ReferenceError → catch に落ちて 500「カード登録の準備中にエラーが発生しました」を返す状態だった
- 新規登録〜初回カード登録の導線と、campaignCode のバックエンド連携（#285〜#294 のキャンペーン機能）が全滅するため、次回リリース前に必須の修正
- `next.config.mjs` の `typescript.ignoreBuildErrors: true` により型エラーのままビルド・デプロイが通過してしまうことが見逃しの原因

## 変更内容
呼び出しを PR #279 の他ルートと同じ `const { response } = await authenticatedFetch(...)` パターンに修正（1行）

## Test plan
- 修正前: `pnpm exec tsc --noEmit` で `src/app/api/payment/register/route.ts(48,28): error TS2304: Cannot find name 'secureFetchWithCommonHeaders'.`
- 修正後: 同コマンドで当該ファイルのエラーなし（残る114件は今回差分外の既存型ドリフト）
- `next lint --file src/app/api/payment/register/route.ts` エラー・警告なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)