### PR TITLE
[Fix] 無料期間終了後はキャンペーン適用中カードを表示しない (#457)

### DIFF
--- a/frontend/src/hooks/useCurrentCampaign.ts
+++ b/frontend/src/hooks/useCurrentCampaign.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react"
 import type { PlanManagementCampaignInfo } from "@/components/molecules/PlanManagement"
+import { isCampaignFreePeriodActive } from "@/lib/date-utils"
 
 export function useCurrentCampaign(enabled: boolean): PlanManagementCampaignInfo | null {
   const [campaignInfo, setCampaignInfo] = useState<PlanManagementCampaignInfo | null>(null)
@@ -18,7 +19,11 @@ export function useCurrentCampaign(enabled: boolean): PlanManagementCampaignInfo
         if (!res.ok) return
         const data = await res.json()
         if (cancelled) return
-        if (data?.hasActiveCampaign && data.application) {
+        if (
+          data?.hasActiveCampaign &&
+          data.application &&
+          isCampaignFreePeriodActive(data.application.firstBillingDate)
+        ) {
           setCampaignInfo({
             freeDaysApplied: data.application.freeDaysApplied,
             firstBillingDate: data.application.firstBillingDate,

--- a/frontend/src/hooks/usePaymentReturn.ts
+++ b/frontend/src/hooks/usePaymentReturn.ts
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
+import { isCampaignFreePeriodActive } from '@/lib/date-utils'
 
 export interface CampaignInfo {
   freeDaysApplied: number
@@ -144,7 +145,11 @@ export const usePaymentReturn = () => {
             const campaignResponse = await fetch('/api/campaigns/me/current', { credentials: 'include' })
             if (campaignResponse.ok) {
               const data = await campaignResponse.json()
-              if (data?.hasActiveCampaign && data.application) {
+              if (
+                data?.hasActiveCampaign &&
+                data.application &&
+                isCampaignFreePeriodActive(data.application.firstBillingDate)
+              ) {
                 hasCampaign = true
                 setCampaignInfo({
                   freeDaysApplied: data.application.freeDaysApplied,

--- a/frontend/src/lib/date-utils.ts
+++ b/frontend/src/lib/date-utils.ts
@@ -20,6 +20,11 @@ export function formatJstYmd(iso: string): string {
   return jstJapaneseDateFormatter.format(new Date(iso))
 }
 
+export function isCampaignFreePeriodActive(firstBillingDateIso: string): boolean {
+  const firstBillingDate = new Date(firstBillingDateIso).getTime()
+  return Number.isFinite(firstBillingDate) && firstBillingDate > Date.now()
+}
+
 export function computeFreePeriodEnd(firstBillingDateIso: string): string {
   const d = new Date(firstBillingDateIso)
   d.setUTCDate(d.getUTCDate() - 1)


### PR DESCRIPTION
## 概要

無料期間が終了したユーザーに対して、プラン変更画面の「キャンペーン適用中」カードを表示しないようにする。

## 背景

キャンペーンカードの表示は API `/api/campaigns/me/current` の `hasActiveCampaign` のみで決まる。この値は `UserCampaignApplication.status` を見ており、`status` を `completed` にするのは初回課金日翌日 0:30 JST の日次バッチである。

そのため無料期間終了後も最大約24.5時間、`status` が `active` のまま残り、カードが「キャンペーン適用中 ¥0」「初回決済日：（過去日）」と表示され続けていた。

API 側（tamanomi-api）で `firstBillingDate` による判定を追加しており、本 PR はそれに合わせた画面側の多層防御。API のデプロイ順序や古いレスポンスが返った場合でも、画面側で表示を止める。

## 仕様

| 判定 | Before | After |
|---|---|---|
| campaignInfo を採用するか | `hasActiveCampaign && application` | 左記 **かつ** `firstBillingDate > 現在時刻` |

`firstBillingDate` は JST 0:00 を UTC で保持しているため、時刻同士の比較でよくタイムゾーン変換は不要。

## 修正点

| ファイル | 内容 |
|---|---|
| `frontend/src/lib/date-utils.ts` | `isCampaignFreePeriodActive()` を新設。不正な日付文字列は `Number.isFinite` で false に落とす |
| `frontend/src/hooks/useCurrentCampaign.ts` | campaignInfo の採用条件に上記判定を追加 |
| `frontend/src/hooks/usePaymentReturn.ts` | 同上（カード登録直後は `firstBillingDate` が必ず未来のため挙動は変わらないが、判定を揃える） |

## 挙動の変化

無料期間終了後〜日次バッチ実行前のみ変わる。

| 画面 | Before | After |
|---|---|---|
| プラン変更画面 | キャンペーンカード（¥0・無料期間表示） | 通常のプラン変更画面 |
| 退会確認画面 注意事項2 | 「無料期間は終了し、サービスをご利用いただけません」 | 「ご契約期間の終了日まではサービスをご利用いただけます」 |

無料期間中およびバッチ実行後の挙動は変わらない。

## 関連

- Issue https://github.com/HV-development/tamanomi-api/issues/457
- API 側: https://github.com/HV-development/tamanomi-api/pull/459
- ミラー: nomoca-kagawa-web の同名ブランチ