### PR TITLE
fix(plans): 次回請求日を未来日のときのみ表示する

### DIFF
--- a/frontend/src/components/molecules/PlanManagement.tsx
+++ b/frontend/src/components/molecules/PlanManagement.tsx
@@ -4,7 +4,7 @@ import { Crown, Settings } from "lucide-react"
 import { format } from "date-fns"
 import { ja } from "date-fns/locale"
 import type { Plan } from "../../types/user"
-import { formatJstYmd, computeFreePeriodEndYmd } from "@/lib/date-utils"
+import { formatJstYmd, computeFreePeriodEndYmd, isFutureBillingDate } from "@/lib/date-utils"
 
 export interface PlanManagementCampaignInfo {
   freeDaysApplied: number
@@ -86,7 +86,7 @@ export function PlanManagement({ plan, onChangePlan, onChangePaymentMethod, hasP
 
               <div className="space-y-2 text-sm text-green-800">
                 <div>開始日：{formatDate(plan.startDate)}</div>
-                {plan.nextBillingDate && (
+                {isFutureBillingDate(plan.nextBillingDate) && (
                   <div>次回請求日：{formatDate(plan.nextBillingDate)}</div>
                 )}
               </div>

--- a/frontend/src/components/molecules/PlanSection.tsx
+++ b/frontend/src/components/molecules/PlanSection.tsx
@@ -4,6 +4,7 @@ import { Crown, Calendar } from "lucide-react"
 import { format } from "date-fns"
 import { ja } from "date-fns/locale"
 import { StatusBadge } from "@/components/atoms/StatusBadge"
+import { isFutureBillingDate } from "@/lib/date-utils"
 import type { Plan } from "@/types/user"
 
 interface PlanSectionProps {
@@ -46,7 +47,7 @@ export function PlanSection({ plan, onChangePlan, onCancelSubscription, classNam
             <span>開始日: {formatDate(plan.startDate)}</span>
           </div>
 
-          {plan.nextBillingDate && (
+          {isFutureBillingDate(plan.nextBillingDate) && (
             <div className="flex items-center gap-2 text-sm text-green-600 mt-1">
               <Calendar className="w-4 h-4" />
               <span>次回請求日: {formatDate(plan.nextBillingDate)}</span>

--- a/frontend/src/lib/date-utils.ts
+++ b/frontend/src/lib/date-utils.ts
@@ -12,6 +12,13 @@ const jstJapaneseDateFormatter = new Intl.DateTimeFormat('ja-JP', {
   day: 'numeric',
 })
 
+const jstIsoDateFormatter = new Intl.DateTimeFormat('en-CA', {
+  timeZone: 'Asia/Tokyo',
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+})
+
 export function formatJstDate(iso: string): string {
   return jstSlashDateFormatter.format(new Date(iso))
 }
@@ -23,6 +30,19 @@ export function formatJstYmd(iso: string): string {
 export function isCampaignFreePeriodActive(firstBillingDateIso: string): boolean {
   const firstBillingDate = new Date(firstBillingDateIso).getTime()
   return Number.isFinite(firstBillingDate) && firstBillingDate > Date.now()
+}
+
+/**
+ * nextBillingDate を進めるのは日次バッチ(0:30 JST)だけなので、課金日当日は初回課金日の
+ * ままになる。過ぎた日を「次回」として出さないよう、JST 日付で明日以降のときだけ true。
+ */
+export function isFutureBillingDate(
+  value: Date | string | null | undefined,
+): value is Date | string {
+  if (!value) return false
+  const date = value instanceof Date ? value : new Date(value)
+  if (!Number.isFinite(date.getTime())) return false
+  return jstIsoDateFormatter.format(date) > jstIsoDateFormatter.format(new Date())
 }
 
 export function computeFreePeriodEnd(firstBillingDateIso: string): string {


### PR DESCRIPTION
## 概要

課金日当日に「次回請求日」として、すでに課金された日付が表示される問題を修正します。

## 背景

`next_billing_date` を進めるのは日次バッチ（`sync-next-billing-date-from-paygent`、0:30 JST）だけです。バッチは「次回請求日が昨日以前」のユーザーを対象にするため、課金日当日はまだ更新されません。

| 時刻 | next_billing_date | 表示 |
|---|---|---|
| 7/29 00:00（無料期間終了） | 7/29 | 次回請求日：7/29 |
| 7/29 06:00（初回課金実行） | 7/29 | 次回請求日：7/29（課金済みの日を「次回」と表示） |
| 7/30 00:30（バッチ実行） | 8/29 | 次回請求日：8/29 |

最大約 24.5 時間、過ぎた日付を「次回請求日」として案内していました。

正しい値はバッチが動くまで DB に存在しないため、「正しい値が分からない間は表示しない」方針としています。

## 仕様

| 条件 | Before | After |
|---|---|---|
| next_billing_date が明日以降（JST） | 表示 | 表示 |
| next_billing_date が今日または過去（JST） | 表示 | **非表示** |
| next_billing_date が未設定 | 非表示 | 非表示 |

副作用として、通常ユーザーも課金日当日は次回請求日が非表示になります（翌 0:30 のバッチ反映まで約1日）。

## 修正点

| ファイル | 内容 |
|---|---|
| `frontend/src/lib/date-utils.ts` | `isFutureBillingDate()` を追加。JST 日付で明日以降なら true を返す型述語 |
| `frontend/src/components/molecules/PlanManagement.tsx` | 次回請求日の表示条件を差し替え |
| `frontend/src/components/molecules/PlanSection.tsx` | 同上 |

## API 側で null を返さない理由

`PlanChangeForm` は `nextBillingDate` が無い場合、`application.first_executed_date` → 「今日から1ヶ月後」の順にフォールバックします。API で null を返すとプラン変更の確認画面に根拠のない日付が表示されるため、表示側でのみ隠しています。

## 動作確認

| ケース | 内容 | 期待 | 結果 |
|---|---|---|---|
| 1 | キャンペーン初回課金日当日（バッチ前） | 次回請求日が非表示 | Pass |
| 2 | 翌日バッチ反映後 | 次回請求日 2026年8月29日を表示 | Pass |

型チェック（`tsc --noEmit`）は変更前と同数で、新規エラーはありません。

## 関連

| 種別 | 内容 |
|---|---|
| Issue | #456, #457 |
| 先行 PR | tamanomi-web #296 / nomoca-kagawa-web #173 |
| API | tamanomi-api の https://github.com/HV-development/tamanomi-api/pull/470 |