### PR TITLE
feat(web): キャンペーン案内リンクをレシートクエストLPに変更

### DIFF
--- a/frontend/src/components/molecules/CampaignCodeCard.tsx
+++ b/frontend/src/components/molecules/CampaignCodeCard.tsx
@@ -156,7 +156,9 @@ export function CampaignCodeCard({ appliedCampaign, onApplied }: CampaignCodeCar
         </div>
         <div className="flex justify-start">
           <a
-            href="/lp/faq"
+            href="https://receipt-quest.saitama-tsunagu.com/#tokten"
+            target="_blank"
+            rel="noopener noreferrer"
             className="inline-block border-b border-[#3273f6] pb-[2px] text-[10px] text-[#3273f6]"
           >
             キャンペーンについてはこちら


### PR DESCRIPTION
## 概要

プラン登録・変更画面のキャンペーンコード入力カードにある「キャンペーンについてはこちら」の遷移先を、たまのみサイト内のFAQからレシートクエストLPの特典セクションに変更しました。

## 背景

キャンペーンの詳細説明はレシートクエストLP側に集約されているため、サイト内FAQではなくLPの特典セクションへ直接案内する必要がありました。

## 仕様

| 項目 | Before | After |
| --- | --- | --- |
| リンク先 | `/lp/faq`（サイト内FAQ） | `https://receipt-quest.saitama-tsunagu.com/#tokten` |
| 開き方 | 同一タブ遷移 | 別タブ（`target="_blank"`） |
| リンク文言・スタイル | 「キャンペーンについてはこちら」 | 変更なし |

- 外部サイトへの遷移になるため別タブで開き、登録・変更操作中の画面から離れないようにしています。
- `#tokten` はLP内の特典セクションへのアンカーです。

## 修正点

| ファイル | 内容 |
| --- | --- |
| `frontend/src/components/molecules/CampaignCodeCard.tsx` | `href` を `/lp/faq` から `https://receipt-quest.saitama-tsunagu.com/#tokten` に変更。`target="_blank"` / `rel="noopener noreferrer"` を付与 |

## 影響範囲

| 対象 | 状態 |
| --- | --- |
| tamanomi-web | 本PRで対応 |
| nomoca-kagawa-web | 対象外（たまのみのみの変更） |

## 確認観点

| # | 確認内容 | 期待結果 |
| --- | --- | --- |
| 1 | プラン登録画面のキャンペーンコード入力カード下のリンクを押す | 別タブでレシートクエストLPが開き、特典セクションまでスクロールされる |
| 2 | リンクを押した後、元のタブの状態 | 入力中の内容が保持されたまま登録画面が残っている |
| 3 | プラン変更画面でも同様に確認 | 同上 |

## 関連

- リンク先LP: https://receipt-quest.saitama-tsunagu.com/#tokten