### PR TITLE
fix(plan-registration): キャンペーンコード入力欄のSP崩れを修正

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -115,3 +115,5 @@ Thumbs.db
 .auth/
 test-results/
 playwright-report/
+
+certificates

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -115,5 +115,3 @@ Thumbs.db
 .auth/
 test-results/
 playwright-report/
-
-certificates

--- a/frontend/src/components/molecules/CampaignCodeCard.tsx
+++ b/frontend/src/components/molecules/CampaignCodeCard.tsx
@@ -120,7 +120,7 @@ export function CampaignCodeCard({ appliedCampaign, onApplied }: CampaignCodeCar
                 onChange={(e) => handleChange(e.target.value)}
                 placeholder="キャンペーンコード"
                 disabled={isApplied || isApplying}
-                className="min-w-0 flex-1 bg-transparent text-sm sm:text-base font-medium text-black placeholder:text-[#9aa39a] focus:outline-none disabled:cursor-not-allowed"
+                className="min-w-0 flex-1 bg-transparent text-base font-medium text-black placeholder:text-[#9aa39a] focus:outline-none disabled:cursor-not-allowed"
                 inputMode="text"
                 autoComplete="off"
                 autoCapitalize="off"

--- a/frontend/src/components/molecules/CampaignCodeCard.tsx
+++ b/frontend/src/components/molecules/CampaignCodeCard.tsx
@@ -108,7 +108,7 @@ export function CampaignCodeCard({ appliedCampaign, onApplied }: CampaignCodeCar
 
       <div className="space-y-1.5">
         <div className="flex items-start gap-2">
-          <div className="flex-1 space-y-1.5">
+          <div className="flex-1 min-w-0 space-y-1.5">
             <div
               className={`relative flex h-10 items-center rounded-[10px] border px-3 ${
                 isApplied ? "border-[#049a2a] bg-white" : "border-[#d9d9d9] bg-white"
@@ -120,7 +120,7 @@ export function CampaignCodeCard({ appliedCampaign, onApplied }: CampaignCodeCar
                 onChange={(e) => handleChange(e.target.value)}
                 placeholder="キャンペーンコード"
                 disabled={isApplied || isApplying}
-                className="flex-1 bg-transparent text-base font-medium text-black placeholder:text-[#9aa39a] focus:outline-none disabled:cursor-not-allowed"
+                className="min-w-0 flex-1 bg-transparent text-sm sm:text-base font-medium text-black placeholder:text-[#9aa39a] focus:outline-none disabled:cursor-not-allowed"
                 inputMode="text"
                 autoComplete="off"
                 autoCapitalize="off"


### PR DESCRIPTION
## 概要
SP表示でプラン登録画面のキャンペーンコード入力欄がカードからはみ出し、「適用する」ボタンが画面外に押し出される表示崩れを修正。

## 背景
ユーザーからのスクリーンショット報告により発覚。tamanomi.com のプラン登録画面をSP（iPhone Safari）で開くと、キャンペーンコード入力欄が想定より大きく描画され、右側の「適用する」ボタンがカード外・画面外にはみ出していた。
<img width="240" height="546" alt="IMG_0396" src="https://github.com/user-attachments/assets/8420fcde-5e08-45a6-8838-69c5ec315b9c" />


## 仕様

| 項目 | 修正前 | 修正後 |
|---|---|---|
| 入力欄とボタンの横並び | Safari(WebKit)のflexbox仕様で入力欄が縮まず、カード外にはみ出す | 入力欄が正しく縮み、ボタンと一緒にカード内へ収まる |
| 入力文字サイズ | 常に16px | sm未満（狭い画面）は14px、sm以上は16px |

## 修正点

| ファイル | 変更内容 |
|---|---|
| `frontend/src/components/molecules/CampaignCodeCard.tsx` | 入力欄の親要素・input自体に `min-w-0` を追加。入力文字サイズを `text-sm sm:text-base` に変更 |



## 関連
- nomoca-kagawa-web 側に同一修正あり https://github.com/HV-development/nomoca-kagawa-web/pull/176