### PR TITLE
キャンペーンコードの最小文字数を6文字から4文字に緩和

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
-    "@hv-development/schemas": "1.143.0",
+    "@hv-development/schemas": "1.144.0",
     "@radix-ui/react-accordion": "1.2.2",
     "@radix-ui/react-alert-dialog": "1.1.4",
     "@radix-ui/react-aspect-ratio": "1.1.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -13,8 +13,8 @@ dependencies:
     specifier: ^3.10.0
     version: 3.10.0(react-hook-form@7.68.0)
   '@hv-development/schemas':
-    specifier: 1.143.0
-    version: 1.143.0
+    specifier: 1.144.0
+    version: 1.144.0
   '@radix-ui/react-accordion':
     specifier: 1.2.2
     version: 1.2.2(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1)
@@ -579,8 +579,8 @@ packages:
     deprecated: Use @eslint/object-schema instead
     dev: true
 
-  /@hv-development/schemas@1.143.0:
-    resolution: {integrity: sha512-0Zzj8IrX3A10mCP/kquAxLylp4hNlf8KBhUxwjhBYevl0+6i3QJUXJBOFxlixZ3WdMq3wY36Maf4mfvNcViI0Q==, tarball: https://npm.pkg.github.com/download/@hv-development/schemas/1.143.0/bf6023b0c311558ad5b4dc8d7a8adc8affc69088}
+  /@hv-development/schemas@1.144.0:
+    resolution: {integrity: sha512-fI2X07s4GhtPmyGxuqMuMMWlwi/qR7P/vzbJ1GJNFa9qLCjdkv3q/GSMXcV0XGIFfFJI80zzvIIkYf0RsUAZPg==, tarball: https://npm.pkg.github.com/download/@hv-development/schemas/1.144.0/605d77d844ac0fe929676f58e378a1dbed529e98}
     engines: {node: 22.x}
     dependencies:
       zod: 3.25.76

--- a/frontend/src/components/molecules/CampaignCodeCard.tsx
+++ b/frontend/src/components/molecules/CampaignCodeCard.tsx
@@ -30,7 +30,7 @@ interface ValidateFailureResponse {
 
 type ValidateResponse = ValidateSuccessResponse | ValidateFailureResponse
 
-const CODE_PATTERN = /^[a-z0-9]{6,20}$/
+const CODE_PATTERN = /^[a-z0-9]{4,20}$/
 
 export function CampaignCodeCard({ appliedCampaign, onApplied }: CampaignCodeCardProps) {
   const [code, setCode] = useState<string>("")
@@ -53,7 +53,7 @@ export function CampaignCodeCard({ appliedCampaign, onApplied }: CampaignCodeCar
       return
     }
     if (!CODE_PATTERN.test(normalized)) {
-      setErrorMessage("6〜20文字の英小文字・半角数字で入力してください")
+      setErrorMessage("4〜20文字の英小文字・半角数字で入力してください")
       return
     }
 


### PR DESCRIPTION
## 概要

プラン申込画面のキャンペーンコード入力について、最小文字数を 6 文字から 4 文字に緩和する。

## 背景

先方運用にて、無料期間キャンペーンのコードを `5959`（4桁の数字）で登録したいとのご要望があった。
管理画面側で登録できるようにしても、一般ユーザーの入力欄が 6 文字以上を必須としているため、
本 PR がないとユーザーがコードを適用できない。

## 仕様

| 項目 | Before | After |
| --- | --- | --- |
| 入力パターン | `/^[a-z0-9]{6,20}$/` | `/^[a-z0-9]{4,20}$/` |
| エラーメッセージ | 6〜20文字の英小文字・半角数字で入力してください | 4〜20文字の英小文字・半角数字で入力してください |

## 修正点

| ファイル | 内容 |
| --- | --- |
| `frontend/src/components/molecules/CampaignCodeCard.tsx` | `CODE_PATTERN` を `{4,20}` に変更。エラーメッセージ文言を更新 |
| `frontend/package.json` / `pnpm-lock.yaml` | `@hv-development/schemas` を 1.144.0 に更新（カード登録時の `campaignCode` 検証も 4 文字以上に緩和） |

## 動作確認手順

事前に管理画面で 4 文字のキャンペーンコード（例: `5959`）を登録しておく。

| # | ケース | 期待結果 |
| --- | --- | --- |
| 1 | コード欄に `5959` を入力して「適用する」 | 適用され、無料期間が反映される |
| 2 | コード欄に `595` を入力して「適用する」 | 「4〜20文字の英小文字・半角数字で入力してください」が表示され API を叩かない |
| 3 | コード欄に `SPRING2026` と大文字で入力 | 従来どおり自動で小文字化されて適用される |
| 4 | コード適用後にカード登録まで進む | 400 エラーにならず登録できる |
| 5 | 存在しない 4 文字コードを入力 | 「このコードは無効です」が表示される |

## 関連

- HV-development/tamanomi-schemas（先にマージが必要）
- HV-development/tamanomi-api
- 管理画面側の対応 PR（tamanomi-admin / nomoca-kagawa-admin）